### PR TITLE
hlcy, 1ref, mnvv, cpofp, solar, ssrun, vig, vbdsf, vddsf

### DIFF
--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -330,23 +330,18 @@ class fieldData(UPPData):
             # Available variable levels
             dim_name = spec.get('vertical_level_name',
                                 field.dimensions[0])
-            print('grib.py: dim_name = ', dim_name)
             levs = self.contents.variables[dim_name][::]
-            print('grib.py: levs = ', levs)
 
             # Requested level
             lev_val, lev_unit = self.numeric_level()
             lev_val = lev_val / 100. if lev_unit == 'cm' else lev_val
             lev_val = lev_val * 100. if lev_unit in ['mb', 'mxmb'] else lev_val
             lev_val = lev_val * 1000. if lev_unit in ['km', 'mx', 'sr'] else lev_val
-            print('grib.py: lev_val, lev_unit = ', lev_val, lev_unit)
 
             # The index of the requested level
             lev = spec.get('vertical_index')
-            print('grib.py: lev = ', lev)
             if lev is None:
                 lev = int(np.argwhere(levs == lev_val))
-            print('grib.py: lev = ', lev)
             vals = field[lev, :, :]
 
             transforms = spec.get('transform')

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -55,6 +55,31 @@
 #      anchor needs to be applied before another section.
 #
 
+1hsm: # Helicity
+  sfc: &hlcy # 0-1 km Storm Relative Helicity
+    clevs: [25, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800]
+    cmap: gist_ncar
+    colors: hlcy_colors
+    layer: 0
+    ncl_name: HLCY_P0_2L103_GLC0
+    ticks: 0
+    title: 0-1 km Storm Relative Helicity
+    unit: m2/s2
+1ref: # Composite reflectivity
+  1000m: &refl
+    clevs: !!python/object/apply:numpy.arange [5, 76, 5]
+    cmap: NWSReflectivity
+    colors: cref_colors
+    ncl_name: REFD_P0_L103_GLC0
+    ticks: 5
+    title: 1 km agl Reflectivity
+    unit: dBZ
+3hsm: # Helicity
+  sfc: # 0-3 km Storm Relative Helicity
+    <<: *hlcy
+    layer: 1
+    ncl_name: HLCY_P0_2L103_GLC0
+    title: 0-3 km Storm Relative Helicity
 acpcp: # Accumulated precipitation
   sfc: # Not yet supported
     clevs: [0.01, 0.1, 0.25, 0.5, 1, 2, 3, 5, 10, 15, 20, 40]
@@ -163,13 +188,19 @@ cloudcover:
     ncl_name: TCDC_P0_L10_GLC0
     title: Total Cloud Cover
 cref: # Composite reflectivity
-  sfc: &refl
-    clevs: !!python/object/apply:numpy.arange [5, 76, 5]
-    cmap: NWSReflectivity
-    colors: cref_colors
+  sfc:
+    <<: *refl
     ncl_name: REFC_P0_L10_GLC0
-    ticks: 5
-    unit: dB
+    title: Composite Reflectivity
+cpofp:
+  sfc: # Frozen Precipitation Percentage
+    clevs: [-0.1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+    cmap: gist_ncar
+    colors: frzn_colors
+    ncl_name: CPOFP_P0_L1_GLC0
+    ticks: 0
+    title: Frozen Precip Percentage
+    unit: '%'
 ctop: # Cloud top height
   ua:
     clevs: !!python/object/apply:numpy.arange [0, 61, 5]
@@ -286,29 +317,54 @@ hailcast: # Max 1h Hail diameter
     ncl_name: HAIL_P8_L1_GLC0_max1h
     title: Max 1h Hail Diameterat Sfc from HAILCAST
 hlcy: # Helicity
-  in16: &hlcy # Hourly updraft helicity over 1-6 km layer
+  in16: # Hourly updraft helicity over 1-6 km layer
+    <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    cmap: gist_ncar
-    colors: hlcy_colors
     layer: 1
     ncl_name: UPHL_P0_2L103_GLC0
     ticks: 25
     title: 1-6km Updraft Helicity
-    unit: m2/s2
   in25: # Hourly updraft helicity over 2-5 km layer
     <<: *hlcy 
+    clevs: !!python/object/apply:numpy.arange [25, 301, 25]
     layer: 0
     ncl_name: UPHL_P0_2L103_GLC0
     title: 2-5km Updraft Helicity
+  mn02: # Hourly minimum of updraft helicity over 0-2 km layer
+    <<: *hlcy
+    clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
+    layer: 0
+    ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
+    ticks: 12.5
+    title: 0-2km Min Updraft Helicity (over prv hr)
+  mn03: # Hourly minimum of updraft helicity over 0-3 km layer
+    <<: *hlcy
+    clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
+    layer: 1
+    ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
+    ticks: 12.5
+    title: 0-3km Min Updraft Helicity (over prv hr)
+  mn16: # Hourly minimum of updraft helicity over 1-6 km layer
+    <<: *hlcy
+    clevs: !!python/object/apply:numpy.arange [25, 301, 25]
+    layer: 3
+    ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
+    title: 1-6km Min Updraft Helicity (over prv hr)
+  mn25: # Hourly minimum of updraft helicity over 2-5 km layer
+    <<: *hlcy
+    clevs: !!python/object/apply:numpy.arange [25, 301, 25]
+    layer: 2
+    ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
+    title: 2-5km Min Updraft Helicity (over prv hr)
   mx02: # Hourly maximum of updraft helicity over 0-2 km layer
-    <<: *hlcy 
+    <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
     layer: 0
     ncl_name: MXUPHL_P8_2L103_GLC0_max1h
     ticks: 12.5
     title: 0-2km Max Updraft Helicity (over prv hr)
   mx03: # Hourly maximum of updraft helicity over 0-3 km layer
-    <<: *hlcy 
+    <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
     layer: 1
     ncl_name: MXUPHL_P8_2L103_GLC0_max1h
@@ -316,11 +372,13 @@ hlcy: # Helicity
     title: 0-3km Max Updraft Helicity (over prv hr)
   mx16: # Hourly maximum of updraft helicity over 1-6 km layer
     <<: *hlcy
+    clevs: !!python/object/apply:numpy.arange [25, 301, 25]
     layer: 3
-    title: 1-6km Max Updraft Helicity (over prv hr)
     ncl_name: MXUPHL_P8_2L103_GLC0_max1h
+    title: 1-6km Max Updraft Helicity (over prv hr)
   mx25: # Hourly maximum of updraft helicity over 2-5 km layer
     <<: *hlcy
+    clevs: !!python/object/apply:numpy.arange [25, 301, 25]
     layer: 2
     ncl_name: MXUPHL_P8_2L103_GLC0_max1h
     title: 2-5km Max Updraft Helicity (over prv hr)
@@ -394,6 +452,15 @@ ltg3: # Lightning Threat (LTG1 + LTG2)
     ticks: 0
     title: Lightning Threat (comb of LTG1 and LTG2)
     unit: flashes / km^2 / 5 min
+mnvv: # Mean Vertical Veolcity
+  sfc:
+    clevs: [-20, -15, -10, -5, -1, -0.75, -0.5, -0.25, -0.1, 0.1, 0.25, 0.5, 0.75, 1, 5, 10, 15, 20]
+    cmap: nipy_spectral
+    colors: mean_vvel_colors
+    ncl_name: DZDT_P8_2L104_GLC0_avg1h
+    ticks: 0
+    title: Mean Vertical Velocity, sigma layers 0.5-0.8
+    unit: m/s
 mref: # Maximum reflectivity for past hour at 1 km AGL
   sfc:
     <<: *refl
@@ -586,9 +653,28 @@ soilw: # Soil Moisture
     <<: *soilw_levs
     layer: 8
     title: Soil Moisture at 3m
+solar: # Incoming Solar Radiation
+  sfc: &incoming_radiation
+    clevs: [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100]
+    cmap: gist_ncar
+    colors: vort_colors
+    ncl_name: DSWRF_P0_L1_GLC0
+    ticks: 0
+    title: Incoming Solar Radiation
+    unit: W/m^2
 sphum: # Specific humidity
   ua:
     ncl_name: SPFH_P0_L105_GLC0
+ssrun: # Storm Surface Runoff
+  sfc: &precip
+    clevs: [0.002, 0.01, 0.05, 0.1, 0.25, 0.50, 0.75, 1.0, 2.0]
+    cmap: gist_ncar
+    colors: pcp_colors
+    ncl_name: SSRUN_P8_L1_GLC0_acc1h
+    ticks: 0
+    title: Storm Surface Runoff
+    transform: conversions.kgm2_to_in
+    unit: in
 temp: # Temperature
   2ds: # 2m - Sfc
     clevs: !!python/object/apply:numpy.arange [-16, 17, 2]
@@ -649,15 +735,10 @@ temp: # Temperature
     <<: *ua_temp
 totp: # Hourly total precipitation
   sfc:
-    clevs: [0.002, 0.01, 0.05, 0.1, 0.25, 0.50, 0.75, 1.0, 2.0]
-    cmap: gist_ncar
-    colors: pcp_colors
+    <<: *precip
     contour_colors: red
     ncl_name: APCP_P8_L1_GLC0_acc1h
-    ticks: 0
     title: 1 hr Total Precip
-    transform: conversions.kgm2_to_in
-    unit: in
 u:
   10m:
     ncl_name: UGRD_P0_L103_GLC0
@@ -715,11 +796,30 @@ v:
   925mb: *ua_vwind
   ua:
     <<: *ua_vwind
+vbdsf: # Incoming Direct Radiation
+  sfc:
+    <<: *incoming_radiation
+    ncl_name: VBDSF_P0_L1_GLC0
+    title: Incoming Direct Radiation
+vddsf: # Incoming Diffuse Radiation
+  sfc:
+    <<: *incoming_radiation
+    ncl_name: VDDSF_P0_L1_GLC0
+    title: Incoming Diffuse Radiation
 vil: # Vertically Integrated Liquid
   sfc:
     <<: *vert_int_liq
     ncl_name: VAR_0_16_201_P0_L10_GLC0
     title: Vertically Integrated Liquid
+vig: # Vertically-integrated graupel
+  sfc:
+    clevs: !!python/object/apply:numpy.arange [5, 91, 5]
+    cmap: jet
+    colors: graupel_colors
+    ncl_name: TCOLG_P8_L200_GLC0_max1h
+    ticks: 0
+    title: Max Vertically Integrated Graupel (over previous hour)
+    unit: mm
 vis: # Visibility
   sfc:
     clevs: [0.0625, 0.125, 0.25, 0.5, 1, 1.5, 2, 3, 4, 5, 10, 30, 50]

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -15,9 +15,6 @@
 #
 #   contour: specifies a field to be contoured, and must come from same level
 #
-#   layer: for arrays with multiple fields stacked in the vertical,
-#          provide the desired level
-#
 #   ncl_name: the name of the variable as expected by NCL
 #
 #   ticks: the number of tick marks on the colorbar
@@ -35,6 +32,14 @@
 #                     and their values.
 #
 #   unit: the resulting unit of the variable
+#
+#   vertical_index: index in grib2 file that gives the level
+#                        of 2D field when two or more fields are "stacked"
+#                        into a single 3D array.
+#
+#   vertical_level_name: name of variable in grib2 file that holds the level
+#                        (or bottom level of a layer) of 2D field when two or
+#                        more fields are "stacked" into a single 3D array.
 #
 #   wind: a boolean variable that switches on/off the wind barbs drawn from the
 #         wind at the same level, OR a string specifying the key for the desired
@@ -55,17 +60,7 @@
 #      anchor needs to be applied before another section.
 #
 
-1hsm: # Helicity
-  sfc: &hlcy # 0-1 km Storm Relative Helicity
-    clevs: [25, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800]
-    cmap: gist_ncar
-    colors: hlcy_colors
-    layer: 0
-    ncl_name: HLCY_P0_2L103_GLC0
-    ticks: 0
-    title: 0-1 km Storm Relative Helicity
-    unit: m2/s2
-1ref: # Composite reflectivity
+1ref: # Reflectivity at 1 km AGL
   1000m: &refl
     clevs: !!python/object/apply:numpy.arange [5, 76, 5]
     cmap: NWSReflectivity
@@ -74,12 +69,7 @@
     ticks: 5
     title: 1 km agl Reflectivity
     unit: dBZ
-3hsm: # Helicity
-  sfc: # 0-3 km Storm Relative Helicity
-    <<: *hlcy
-    layer: 1
-    ncl_name: HLCY_P0_2L103_GLC0
-    title: 0-3 km Storm Relative Helicity
+    vertical_level_name: lv_HTGL7
 acpcp: # Accumulated precipitation
   sfc: # Not yet supported
     clevs: [0.01, 0.1, 0.25, 0.5, 1, 2, 3, 5, 10, 15, 20, 40]
@@ -95,19 +85,20 @@ cape:
     clevs: [1, 100, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000]
     cmap: gist_ncar
     colors: vort_colors
-    layer: 2
     ncl_name: CAPE_P0_2L108_GLC0
     ticks: 0
     title: Most Unstable CAPE
     unit: J/kg
+    vertical_index: 2
+    vertical_level_name: lv_SPDL4_l0
   mul: # Most Unstable Layer CAPE
     <<: *cape
-    layer: 1
+    vertical_index: 1
     ncl_name: CAPE_P0_2L108_GLC0
     title: Most Unstable Layer CAPE
   mx90mb: # Lowest 90 mb Mixed Layer CAPE
     <<: *cape
-    layer: 0
+    vertical_index: 0
     ncl_name: CAPE_P0_2L108_GLC0
     title: Lowest 90 mb Mixed Layer CAPE
   sfc:
@@ -146,9 +137,13 @@ ceilexp2: # Ceiling - experimental no.2
     title: Ceiling (exp-2)
 cin: # Surface Convective Inhibition
   mu:
+    clevs: [-300, -200, -150, -100, -75, -50, -40, -30, -20, -10, -1]
+    cmap: gist_ncar
+    colors: cin_colors
     ncl_name: CIN_P0_2L108_GLC0
-    layer: 2
     unit: J/kg
+    vertical_index: 2
+    vertical_level_name: lv_SPDL4_l0
   sfc:
     clevs: [-300, -200, -150, -100, -75, -50, -40, -30, -20, -10, -1]
     cmap: gist_ncar
@@ -192,8 +187,8 @@ cref: # Composite reflectivity
     <<: *refl
     ncl_name: REFC_P0_L10_GLC0
     title: Composite Reflectivity
-cpofp:
-  sfc: # Frozen Precipitation Percentage
+cpofp: # Frozen Precipitation Percentage
+  sfc:
     clevs: [-0.1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
     cmap: gist_ncar
     colors: frzn_colors
@@ -282,6 +277,7 @@ gh: # Geopotential height
   sfc:
     <<: *ua_gh
     clevs: !!python/object/apply:numpy.arange [0, 5000, 250]
+    cmap: gist_earth
     ncl_name: HGT_P0_L1_GLC0
     ticks: 0
     transform: []
@@ -317,79 +313,100 @@ hailcast: # Max 1h Hail diameter
     ncl_name: HAIL_P8_L1_GLC0_max1h
     title: Max 1h Hail Diameterat Sfc from HAILCAST
 hlcy: # Helicity
-  in16: # Hourly updraft helicity over 1-6 km layer
-    <<: *hlcy
+  in16: &hlcy # Hourly updraft helicity over 1-6 km layer
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    layer: 1
+    cmap: gist_ncar
+    colors: hlcy_colors
     ncl_name: UPHL_P0_2L103_GLC0
     ticks: 25
     title: 1-6km Updraft Helicity
+    unit: m2/s2
+    vertical_index: 1
+    vertical_level_name: lv_HTGL6_l0
   in25: # Hourly updraft helicity over 2-5 km layer
     <<: *hlcy 
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    layer: 0
     ncl_name: UPHL_P0_2L103_GLC0
     title: 2-5km Updraft Helicity
+    vertical_index: 0
   mn02: # Hourly minimum of updraft helicity over 0-2 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
-    layer: 0
     ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
     ticks: 12.5
     title: 0-2km Min Updraft Helicity (over prv hr)
+    vertical_index: 0
+    vertical_level_name: lv_HTGL12_l0
   mn03: # Hourly minimum of updraft helicity over 0-3 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
-    layer: 1
     ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
     ticks: 12.5
     title: 0-3km Min Updraft Helicity (over prv hr)
+    vertical_index: 1
+    vertical_level_name: lv_HTGL12_l0
   mn16: # Hourly minimum of updraft helicity over 1-6 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    layer: 3
     ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
     title: 1-6km Min Updraft Helicity (over prv hr)
+    vertical_index: 3
+    vertical_level_name: lv_HTGL12_l0
   mn25: # Hourly minimum of updraft helicity over 2-5 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    layer: 2
     ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
     title: 2-5km Min Updraft Helicity (over prv hr)
+    vertical_index: 2
+    vertical_level_name: lv_HTGL12_l0
   mx02: # Hourly maximum of updraft helicity over 0-2 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
-    layer: 0
     ncl_name: MXUPHL_P8_2L103_GLC0_max1h
     ticks: 12.5
     title: 0-2km Max Updraft Helicity (over prv hr)
+    vertical_index: 0
+    vertical_level_name: lv_HTGL12_l1
   mx03: # Hourly maximum of updraft helicity over 0-3 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
-    layer: 1
     ncl_name: MXUPHL_P8_2L103_GLC0_max1h
     ticks: 12.5
     title: 0-3km Max Updraft Helicity (over prv hr)
+    vertical_index: 1
+    vertical_level_name: lv_HTGL12_l0
   mx16: # Hourly maximum of updraft helicity over 1-6 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    layer: 3
     ncl_name: MXUPHL_P8_2L103_GLC0_max1h
     title: 1-6km Max Updraft Helicity (over prv hr)
+    vertical_index: 3
+    vertical_level_name: lv_HTGL12_l0
   mx25: # Hourly maximum of updraft helicity over 2-5 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    layer: 2
     ncl_name: MXUPHL_P8_2L103_GLC0_max1h
     title: 2-5km Max Updraft Helicity (over prv hr)
-  sr01:
-    layer: 0
+    vertical_index: 2
+    vertical_level_name: lv_HTGL12_l0
+  sr01: # 0-1 km Storm Relative Helicity
+    <<: *hlcy
+    clevs: [25, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800]
     ncl_name: HLCY_P0_2L103_GLC0
     unit: $m^2 / s^2$
-  sr03:
-    layer: 1
+    ticks: 0
+    title: 0-1 km Storm Relative Helicity
+    vertical_index: 0
+    vertical_level_name: lv_HTGL5_l0
+  sr03: # 0-3 km Storm Relative Helicity
+    <<: *hlcy
+    clevs: [25, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800]
     ncl_name: HLCY_P0_2L103_GLC0
     unit: $m^2 / s^2$
+    ticks: 0
+    title: 0-3 km Storm Relative Helicity
+    vertical_index: 1
+    vertical_level_name: lv_HTGL5_l0
 hpbl: # Height of Planetary Boundary Layer
   sfc: 
     clevs: [25, 50, 100, 200, 300, 500, 750, 1000, 1500, 2000, 2500, 3000, 4000, 5000]
@@ -452,15 +469,6 @@ ltg3: # Lightning Threat (LTG1 + LTG2)
     ticks: 0
     title: Lightning Threat (comb of LTG1 and LTG2)
     unit: flashes / km^2 / 5 min
-mnvv: # Mean Vertical Veolcity
-  sfc:
-    clevs: [-20, -15, -10, -5, -1, -0.75, -0.5, -0.25, -0.1, 0.1, 0.25, 0.5, 0.75, 1, 5, 10, 15, 20]
-    cmap: nipy_spectral
-    colors: mean_vvel_colors
-    ncl_name: DZDT_P8_2L104_GLC0_avg1h
-    ticks: 0
-    title: Mean Vertical Velocity, sigma layers 0.5-0.8
-    unit: m/s
 mref: # Maximum reflectivity for past hour at 1 km AGL
   sfc:
     <<: *refl
@@ -471,6 +479,7 @@ pres:
     clevs: !!python/object/apply:numpy.arange [650, 1051, 4]
     cmap: gist_ncar
     colors: ps_colors
+    contour_colors: Black
     ncl_name: PRES_P0_L1_GLC0
     ticks: 20
     transform: conversions.pa_to_hpa
@@ -543,16 +552,24 @@ rvil: # Radar-derived Vertically Integrated Liquid
     unit: kg/m^2
 shear:
   01km: &shear # 0-1 km
+    clevs: !!python/object/apply:numpy.arange [5, 91, 5]
+    cmap: jet
+    colors: shear_colors
     ncl_name: VUCSH_P0_2L103_GLC0
-    layer: 1
-    transform: vector_magnitude
+    transform: [vector_magnitude, conversions.ms_to_kt]
     transform_kwargs:
       field2: VVCSH_P0_2L103_GLC0
-      layer: 1
+      vertical_index: 0
+    ticks: 0
     unit: $s^{-1}$
+    vertical_index: 0
+    vertical_level_name: lv_HTGL2_l1
   06km: # 0-6 km
     <<: *shear
-    layer: 0
+    transform_kwargs:
+      field2: VVCSH_P0_2L103_GLC0
+      vertical_index: 1
+    vertical_index: 1
 shtfl: # Sensible Heat Net Flux
   sfc:
     <<: *heat_flux
@@ -570,88 +587,72 @@ soilm: # Soil Moisture Availability
     title: Soil Moisture Availability
     unit: "%"
 soilt: # Soil Temperature
-  sfc: &soilt_levs
+  0cm: &soilt_levs
     clevs: !!python/object/apply:numpy.arange [240, 311, 10]
     cmap: gist_ncar
     colors: soilt_colors
-    layer: 0
     ncl_name: TSOIL_P0_2L106_GLC0
     ticks: 0
     title: Soil Temperature at Sfc
     unit: K
+    vertical_level_name: lv_DBLL10_l0
   1cm:
     <<: *soilt_levs
-    layer: 1
     title: Soil Temperature at 1cm
   4cm:
     <<: *soilt_levs
-    layer: 2
     title: Soil Temperature at 4cm
   10cm:
     <<: *soilt_levs
-    layer: 3
     title: Soil Temperature at 10cm
   30cm:
     <<: *soilt_levs
-    layer: 4
     title: Soil Temperature at 30cm
   60cm:
     <<: *soilt_levs
-    layer: 5
     title: Soil Temperature at 60cm
   1m:
     <<: *soilt_levs
-    layer: 6
     title: Soil Temperature at 1m
   1.6m:
     <<: *soilt_levs
-    layer: 7
     title: Soil Temperature at 1.6m
   3m:
     <<: *soilt_levs
-    layer: 8
     title: Soil Temperature at 3m
 soilw: # Soil Moisture
-  sfc: &soilw_levs
+  0cm: &soilw_levs
     clevs: !!python/object/apply:numpy.arange [0.0, 0.61, 0.1]
     cmap: gist_ncar
     colors: soilw_colors
-    layer: 0
     ncl_name: SOILW_P0_2L106_GLC0
     ticks: 0
     title: Soil Moisture at Sfc
     unit: fraction
+    vertical_level_name: lv_DBLL10_l0
   1cm:
     <<: *soilw_levs
-    layer: 1
     title: Soil Moisture at 1cm
   4cm:
     <<: *soilw_levs
-    layer: 2
     title: Soil Moisture at 4cm
   10cm:
     <<: *soilw_levs
-    layer: 3
     title: Soil Moisture at 10cm
   30cm:
     <<: *soilw_levs
-    layer: 4
     title: Soil Moisture at 30cm
   60cm:
     <<: *soilw_levs
-    layer: 5
     title: Soil Moisture at 60cm
   1m:
     <<: *soilw_levs
-    layer: 6
     title: Soil Moisture at 1m
   1.6m:
     <<: *soilw_levs
-    layer: 7
     title: Soil Moisture at 1.6m
   3m:
     <<: *soilw_levs
-    layer: 8
     title: Soil Moisture at 3m
 solar: # Incoming Solar Radiation
   sfc: &incoming_radiation
@@ -850,17 +851,25 @@ vvel: # Vertical velocity
     ticks: 5
     transform: conversions.vvel_scale
     unit: -Pa/s * 10
+  mean: # Mean Vertical Veolcity
+    clevs: [-20, -15, -10, -5, -1, -0.75, -0.5, -0.25, -0.1, 0.1, 0.25, 0.5, 0.75, 1, 5, 10, 15, 20]
+#    cmap: nipy_spectral
+    cmap: Spectral_r
+    colors: mean_vvel_colors
+    ncl_name: DZDT_P8_2L104_GLC0_avg1h
+    ticks: 0
+    title: Mean Vertical Velocity, sigma layers 0.5-0.8
+    unit: m/s
 vvort: # Vertical vorticity
   mx01: &vvort # Hourly maximum of vertical vorticity over 0-2 km layer
     clevs: !!python/object/apply:numpy.arange [0.0025, 0.0301, 0.0025]
     cmap: gist_ncar
     colors: vort_colors
-    layer: 0
     ncl_name: RELV_P8_2L103_GLC0_max1h
     ticks: 0
     title: 0-1km Max Vertical Velocity (over prev hour)
     unit: 1/s
+    vertical_level_name: lv_HTGL11_l0
   mx02: # Hourly maximum of vertical vorticity over 0-2 km layer
     <<: *vvort 
-    layer: 1
     title: 0-2km Max Vertical Velocity (over prev hour)

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -124,6 +124,17 @@ class VarSpec(abc.ABC):
 
     @property
     @lru_cache()
+    def frzn_colors(self) -> np.ndarray:
+
+        ''' Default color map for Frozen Precip % '''
+
+        grays = cm.get_cmap('Greys', 7)([0, 2])
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          ([120, 90, 85, 80, 70, 60, 50, 25, 20, 15])
+        return np.concatenate((grays, ncar))
+
+    @property
+    @lru_cache()
     def goes_colors(self) -> np.ndarray:
 
         ''' Default color map for simulated GOES IR satellite '''
@@ -132,6 +143,17 @@ class VarSpec(abc.ABC):
         ctable2 = ctables.colortables.get_colortable(self.vspec.get('cmap')) \
                     (range(65, 150))
         return np.concatenate((grays[-1:], grays, ctable2, grays[1:]))
+
+    @property
+    @lru_cache()
+    def graupel_colors(self) -> np.ndarray:
+
+        ''' Default color map for Max Vertically Integrated Graupel '''
+
+        grays = cm.get_cmap('Greys', 3)([0])
+        ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                          (range(20, 128, 6))
+        return np.concatenate((grays, ncar))
 
     @property
     @lru_cache()
@@ -186,6 +208,18 @@ class VarSpec(abc.ABC):
                           (range(4, 125, 4))
         ctable[14] = [1, 1, 1, 1]
         ctable[15] = [1, 1, 1, 1]
+        return ctable
+
+    @property
+    @lru_cache()
+    def mean_vvel_colors(self) -> np.ndarray:
+
+        ''' Default color map for Mean Vertical Velocity '''
+
+        segments = [[15, 56, 5], [85, 113, 3]]
+        ctable = cm.get_cmap(self.vspec.get('cmap'), 128) \
+                (list(chain(*[range(*i) for i in segments])))
+        ctable[9] = [1, 1, 1, 1]
         return ctable
 
     @property
@@ -352,7 +386,7 @@ class VarSpec(abc.ABC):
 
         grays = cm.get_cmap('Greys', 2)([0])
         ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
-                          ([15, 18, 20, 25, 50, 60, 70, 80, 85, 90, 100, 120])
+                          ([15, 18, 20, 25, 50, 60, 70, 80, 83, 90, 100, 120])
         return np.concatenate((grays, ncar))
 
     @property

--- a/adb_graphics/specs.py
+++ b/adb_graphics/specs.py
@@ -216,9 +216,7 @@ class VarSpec(abc.ABC):
 
         ''' Default color map for Mean Vertical Velocity '''
 
-        segments = [[15, 56, 5], [85, 113, 3]]
-        ctable = cm.get_cmap(self.vspec.get('cmap'), 128) \
-                (list(chain(*[range(*i) for i in segments])))
+        ctable = cm.get_cmap(self.vspec.get('cmap'), 128)(range(0, 114, 6))
         ctable[9] = [1, 1, 1, 1]
         return ctable
 
@@ -310,6 +308,17 @@ class VarSpec(abc.ABC):
 
     @property
     @lru_cache()
+    def shear_colors(self) -> np.ndarray:
+
+        ''' Default color map for Vertical Shear '''
+
+        ctable = cm.get_cmap(self.vspec.get('cmap'), 16) \
+                          (range(5, 15))
+        ctable[9] = [1, 1, 1, 1]
+        return ctable
+
+    @property
+    @lru_cache()
     def soilm_colors(self) -> np.ndarray:
 
         ''' Default color map for Soil Moisture Availability '''
@@ -365,6 +374,7 @@ class VarSpec(abc.ABC):
         grays = cm.get_cmap('Greys', 3)([1, 0])
         ncar = cm.get_cmap(self.vspec.get('cmap'), 128) \
                           ([15, 18, 20, 25, 50, 60, 70, 80, 85, 90, 100, 120])
+
         return np.concatenate((grays, ncar))
 
     @property

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -127,13 +127,14 @@ class TestDefaultSpecs():
             'colors': self.is_a_color,
             'contour': self.is_a_key,
             'contour_colors': self.is_a_color,
-            'layer': self.is_int,
             'ncl_name': True,
             'ticks': self.is_number,
             'title': self.is_string,
             'transform': self.is_callable,
             'transform_kwargs': self.is_dict,
             'unit': self.is_string,
+            'vertical_index': self.is_int,
+            'vertical_level_name': self.is_string,
             'wind': self.is_wind,
             }
 


### PR DESCRIPTION
new graphics for:

- min hlcy (4 levels)
- storm relative hlcy (2 levels),
- 1 hr reflectivity
- frozen precip %
- incoming SW/Direct/Diffuse radiation
- mean vertical velocity
- storm surface runoff
- vertically-integrated graupel.

pylint and pytest passed.  plot examples to follow.
