### PR TITLE
Set file type (nat, prs) from the driver level.

### DIFF
--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -8,7 +8,6 @@ specifics of grib files from UPP.
 import abc
 import datetime
 from functools import lru_cache
-import os
 from string import digits, ascii_letters
 
 from matplotlib import cm
@@ -24,18 +23,18 @@ class GribFile():
 
     ''' Wrappers and helper functions for interfacing with pyNIO.'''
 
-    def __init__(self, filename):
+    def __init__(self, filename, filetype):
         self.filename = filename
         self.contents = self._load()
 
-        self.file_type = 'nat' if 'nat' in os.path.basename(filename) else 'prs'
+        self.filetype = filetype
 
     def _load(self):
 
         ''' Internal method that opens the grib file. Returns a grib message
         iterator. '''
 
-        return Nio.open_file(self.filename) # pylint: disable=c-extension-no-member
+        return Nio.open_file(self.filename, format="grib2") # pylint: disable=c-extension-no-member
 
     def get_field(self, ncl_name):
 
@@ -67,8 +66,9 @@ class UPPData(GribFile, specs.VarSpec):
 
         # Parse kwargs first
         config = kwargs.get('config', 'adb_graphics/default_specs.yml')
+        filetype = kwargs.get('filetype', 'prs')
 
-        GribFile.__init__(self, filename)
+        GribFile.__init__(self, filename, filetype)
         specs.VarSpec.__init__(self, config)
 
         self.spec = self.yml
@@ -171,7 +171,7 @@ class UPPData(GribFile, specs.VarSpec):
 
         name = spec.get('ncl_name')
         if isinstance(name, dict):
-            name = name.get(self.file_type)
+            name = name.get(self.filetype)
         return name
 
     def numeric_level(self, level=None):

--- a/create_skewt.py
+++ b/create_skewt.py
@@ -98,6 +98,11 @@ def parse_args():
                         default='wrfnat_hrconus_{FCST_TIME:02d}.grib2',
                         help='File naming convention',
                         )
+    parser.add_argument('--file_type',
+                        choices=('nat', 'prs'),
+                        default='nat',
+                        help='Type of levels contained in grib file.',
+                        )
     parser.add_argument('--max_plev',
                         help='Maximum pressure level to plot for profiles.',
                         type=int,
@@ -121,7 +126,12 @@ def parallel_skewt(cla, fhr, grib_path, site, workdir):
       workdir    output directory
     '''
 
-    skew = skewt.SkewTDiagram(filename=grib_path, loc=site, max_plev=cla.max_plev)
+    skew = skewt.SkewTDiagram(
+        filename=grib_path,
+        filetype=cla.file_type,
+        loc=site,
+        max_plev=cla.max_plev,
+        )
     skew.create_diagram()
     outfile = f"skewt_{skew.site_code}_{skew.site_num}_f{fhr:02d}.png"
     png_path = os.path.join(workdir, outfile)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -354,7 +354,7 @@ class TestDefaultSpecs():
                     assert checker
                 else:
                     assert checker(v)
-                    
+
     def test_keys(self):
 
         ''' Tests each of top-level variables in the config file by calling the helper function. '''
@@ -362,4 +362,3 @@ class TestDefaultSpecs():
         for short_name, spec in self.cfg.items():
             assert '_' not in short_name
             self.check_keys(spec)
-           

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -20,7 +20,7 @@ def test_UPPData(natfile, prsfile):
         def values(self, level=None, name=None, **kwargs):
             return 1
 
-    upp_nat = UPP(natfile, short_name='temp')
+    upp_nat = UPP(natfile, filetype='nat', short_name='temp')
     upp_prs = UPP(prsfile, short_name='temp')
 
     # Ensure appropriate typing and size (where applicable)
@@ -93,7 +93,7 @@ def test_profileData(natfile):
     ''' Test the profileData class methods on a nat file'''
 
     loc = ' BNA   9999 99999  36.12  86.69  597 Nashville, TN\n'
-    profile = grib.profileData(natfile, loc=loc, short_name='temp')
+    profile = grib.profileData(natfile, filetype='nat', loc=loc, short_name='temp')
 
     assert isinstance(profile.get_xypoint(), tuple)
     assert isinstance(profile.values(), np.ndarray)


### PR DESCRIPTION
I made a bad assumption for getting the file type from the file name. NCEP files are named with only date stamps. 

Now pass in file type (nat, prs) from driver script.

Passed tests and linted.