### PR TITLE
Remove existing zip file before starting.

### DIFF
--- a/create_skewt.py
+++ b/create_skewt.py
@@ -169,6 +169,8 @@ def prepare_skewt(cla):
     if cla.zip_dir:
         os.makedirs(cla.zip_dir, exist_ok=True)
         zipf = os.path.join(cla.zip_dir, 'files.zip')
+        if os.path.exists(zipf):
+            os.remove(zipf)
 
     # Load sites
     with open(cla.sites, 'r') as sites_file:


### PR DESCRIPTION
Saw some weird behavior for SkewTs on the web when the task was run a second time. Start out by removing existing zip file so we don't get duplicates in the delivery file.
