### PR TITLE
Fix for grib tests

### DIFF
--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -79,7 +79,8 @@ def test_fieldData(prsfile):
 
     field2 = grib.fieldData(prsfile, fhr=2, level='ua', short_name='ceil')
     transforms = field2.vspec.get('transform')
-    transform_kwargs = field2.vspec.get('transform_kwargs', {})
+    transform_kwargs = transforms.get('kwargs')
+    transforms = transforms.get('funcs')
     assert np.array_equal(field2.get_transform(transforms, field2.values(), transform_kwargs), \
                           field2.field_diff(field2.values(), variable2='gh', level2='sfc') / 304.8)
 


### PR DESCRIPTION
This should have been fixed with my last PR and I missed it.

The change is related to the different behavior now associated with how we call transforms: can be a single function, a list, or a dict. The ceil variable was changed to a dict, but the test was still expecting a list.

