### PR TITLE
Support for RAP domains.

### DIFF
--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -23,11 +23,12 @@ class GribFile():
 
     ''' Wrappers and helper functions for interfacing with pyNIO.'''
 
-    def __init__(self, filename, filetype):
+    def __init__(self, filename, filetype, **kwargs):
         self.filename = filename
         self.contents = self._load()
 
         self.filetype = filetype
+        self.grid_suffix = kwargs.get('grid_suffix', 'GLC0')
 
     def _load(self):
 
@@ -68,7 +69,7 @@ class UPPData(GribFile, specs.VarSpec):
         config = kwargs.get('config', 'adb_graphics/default_specs.yml')
         filetype = kwargs.get('filetype', 'prs')
 
-        GribFile.__init__(self, filename, filetype)
+        GribFile.__init__(self, filename, filetype, **kwargs)
         specs.VarSpec.__init__(self, config)
 
         self.spec = self.yml
@@ -209,7 +210,7 @@ class UPPData(GribFile, specs.VarSpec):
         name = spec.get('ncl_name')
         if isinstance(name, dict):
             name = name.get(self.filetype)
-        return name.format(fhr=self.fhr)
+        return name.format(fhr=self.fhr, grid=self.grid_suffix)
 
     def numeric_level(self, index_match=True, level=None):
 
@@ -535,7 +536,7 @@ class profileData(UPPData):
 
         # Set the NCL name from the specs section, unless otherwise specified
         ncl_name = kwargs.get('ncl_name') or self.ncl_name(var_spec)
-        ncl_name = ncl_name.format(fhr=self.fhr)
+        ncl_name = ncl_name.format(fhr=self.fhr, grid=self.grid_suffix)
 
         if not ncl_name:
             raise errors.NoGraphicsDefinitionForVariable(

--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -368,21 +368,23 @@ class fieldData(UPPData):
         grid_info = {}
 
         grid_info['corners'] = self.corners
-        if self.grid_suffix in ['GLC0', 'GST0']:
+
+        if self.grid_suffix in ['GLC0']:
             attrs =  ['Latin1', 'Latin2', 'Lov']
             grid_info['projection'] = 'lcc'
             grid_info['lat_0'] = 39.0
         elif self.grid_suffix == 'GST0':
-            attrs = ['La1']
+            attrs = ['Lov']
             grid_info['projection'] = 'stere'
-            grid_info['lat_ts'] = lat.attributes['La1'][0]
-            grid_info['lon_0'] = lat.attributes['Lov'][0] - 360
+            grid_info['lat_0'] = 90
+            grid_info['lat_ts'] = 90
+
         else:
             attrs = []
             grid_info['projection'] = 'rotpole'
+            grid_info['lon_0'] = lat.attributes['CenterLon'][0] - 360
             grid_info['o_lat_p'] = 90 - lat.attributes['CenterLat'][0]
             grid_info['o_lon_p'] = 180
-            grid_info['lon_0'] = lat.attributes['CenterLon'][0] - 360
 
         for attr in attrs:
             bm_arg = ncl_to_basemap[attr]
@@ -496,6 +498,13 @@ class fieldData(UPPData):
         u, v = [field_lambda(self.filename, level, var) for var in ['u', 'v']]
 
         return [component.values() for component in [u, v]]
+
+    @property
+    def wind_stride(self):
+
+        ''' Returns the wind stride associated with the field '''
+
+
 
     def windspeed(self) -> np.ndarray:
 

--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -23,11 +23,12 @@ class GribFile():
 
     ''' Wrappers and helper functions for interfacing with pyNIO.'''
 
-    def __init__(self, filename, filetype, **kwargs):
+    def __init__(self, filename, **kwargs):
+
+        # pylint: disable=unused-argument
+
         self.filename = filename
         self.contents = self._load()
-
-        self.filetype = filetype
 
     def _load(self):
 
@@ -73,9 +74,9 @@ class UPPData(GribFile, specs.VarSpec):
 
         # Parse kwargs first
         config = kwargs.get('config', 'adb_graphics/default_specs.yml')
-        filetype = kwargs.get('filetype', 'prs')
+        self.filetype = kwargs.get('filetype', 'prs')
 
-        GribFile.__init__(self, filename, filetype, **kwargs)
+        GribFile.__init__(self, filename, **kwargs)
         specs.VarSpec.__init__(self, config)
 
         self.spec = self.yml
@@ -347,30 +348,27 @@ class fieldData(UPPData):
 
         # Keys are grib names, values are Basemap argument names
         ncl_to_basemap = dict(
-                CenterLon='lon_0',
-                CenterLat='lat_0',
-                Latin2='lat_1',
-                Latin1='lat_2',
-                Lov='lon_0',
-                La1='lat_0',
-                La2='lat_2',
-                Lo1='lon_1',
-                Lo2='lon_2',
-                )
+            CenterLon='lon_0',
+            CenterLat='lat_0',
+            Latin2='lat_1',
+            Latin1='lat_2',
+            Lov='lon_0',
+            La1='lat_0',
+            La2='lat_2',
+            Lo1='lon_1',
+            Lo2='lon_2',
+            )
 
         # Last coordinate listed should be latitude or longitude
-        lat_var, lon_var = self.field.coordinates.split()
+        lat_var, _ = self.field.coordinates.split()
 
         # Get the latitude variable
         lat = self.contents.variables[lat_var]
-        lon = self.contents.variables[lon_var]
 
         grid_info = {}
-
         grid_info['corners'] = self.corners
-
         if self.grid_suffix in ['GLC0']:
-            attrs =  ['Latin1', 'Latin2', 'Lov']
+            attrs = ['Latin1', 'Latin2', 'Lov']
             grid_info['projection'] = 'lcc'
             grid_info['lat_0'] = 39.0
         elif self.grid_suffix == 'GST0':
@@ -378,7 +376,6 @@ class fieldData(UPPData):
             grid_info['projection'] = 'stere'
             grid_info['lat_0'] = 90
             grid_info['lat_ts'] = 90
-
         else:
             attrs = []
             grid_info['projection'] = 'rotpole'

--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -359,10 +359,6 @@ class fieldData(UPPData):
         lat = self.contents.variables[lat_var]
         lon = self.contents.variables[lon_var]
 
-        print('LAT ATTR')
-        for key, val in lat.attributes.items():
-            print(f'{key}: {val}')
-
         grid_info = {}
 
         if self.grid_suffix == 'GLC0':
@@ -383,10 +379,6 @@ class fieldData(UPPData):
             val = lat.attributes[attr]
             val = val[0] if isinstance(val, np.ndarray) else val
             grid_info[bm_arg] = val
-
-        print('GRID INFO')
-        for key, val in grid_info.items():
-            print(f'{key}: {val}')
 
         return grid_info
 

--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -28,7 +28,6 @@ class GribFile():
         self.contents = self._load()
 
         self.filetype = filetype
-        self.grid_suffix = kwargs.get('grid_suffix', 'GLC0')
 
     def _load(self):
 
@@ -48,6 +47,13 @@ class GribFile():
 
         return field
 
+    @property
+    def grid_suffix(self):
+        ''' Return the suffix of the first variable in the file. This should
+        correspond to the grid tag. '''
+
+        var = list(self.contents.variables.keys())[0]
+        return var.split('_')[-1]
 
 class UPPData(GribFile, specs.VarSpec):
 
@@ -362,10 +368,15 @@ class fieldData(UPPData):
         grid_info = {}
 
         if self.grid_suffix == 'GLC0':
+            attrs =  ['Latin1', 'Latin2', 'Lov']
             grid_info['projection'] = 'lcc'
             grid_info['corners'] = self.corners
             grid_info['lat_0'] = 39.0
-            attrs =  ['Latin1', 'Latin2', 'Lov']
+        elif self.grid_suffix == 'GST0':
+            attrs = ['La1', 'Lo1', 'Lov']
+            grid_info['projection'] = 'stere'
+            grid_info['corners'] = self.corners
+            grid_info['lat_ts'] = lat.attributes['La1'][0]
         else:
             attrs = []
             grid_info['projection'] = 'rotpole'

--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -492,13 +492,6 @@ class fieldData(UPPData):
 
         return [component.values() for component in [u, v]]
 
-    @property
-    def wind_stride(self):
-
-        ''' Returns the wind stride associated with the field '''
-
-
-
     def windspeed(self) -> np.ndarray:
 
         ''' Compute the wind speed from the components. '''

--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -389,10 +389,6 @@ class fieldData(UPPData):
             val = val[0] if isinstance(val, np.ndarray) else val
             grid_info[bm_arg] = val
 
-        print('GRID_INFO')
-        for k, v in grid_info.items():
-            print(f'{k}: {v}')
-
         return grid_info
 
     @property

--- a/adb_graphics/datahandler/grib.py
+++ b/adb_graphics/datahandler/grib.py
@@ -156,7 +156,7 @@ class UPPData(GribFile, specs.VarSpec):
         levs = self.contents.variables[dim_name][::]
 
         # Requested level
-        lev_val, _ = self.numeric_level(level)
+        lev_val, _ = self.numeric_level(level=level)
 
         return int(np.argwhere(levs == lev_val))
 
@@ -352,7 +352,7 @@ class fieldData(UPPData):
                 Latin2='lat_1',
                 Latin1='lat_2',
                 Lov='lon_0',
-                La1='lat_1',
+                La1='lat_0',
                 La2='lat_2',
                 Lo1='lon_1',
                 Lo2='lon_2',
@@ -367,20 +367,19 @@ class fieldData(UPPData):
 
         grid_info = {}
 
-        if self.grid_suffix == 'GLC0':
+        grid_info['corners'] = self.corners
+        if self.grid_suffix in ['GLC0', 'GST0']:
             attrs =  ['Latin1', 'Latin2', 'Lov']
             grid_info['projection'] = 'lcc'
-            grid_info['corners'] = self.corners
             grid_info['lat_0'] = 39.0
         elif self.grid_suffix == 'GST0':
-            attrs = ['La1', 'Lo1', 'Lov']
+            attrs = ['La1']
             grid_info['projection'] = 'stere'
-            grid_info['corners'] = self.corners
             grid_info['lat_ts'] = lat.attributes['La1'][0]
+            grid_info['lon_0'] = lat.attributes['Lov'][0] - 360
         else:
             attrs = []
             grid_info['projection'] = 'rotpole'
-            grid_info['corners'] = self.corners
             grid_info['o_lat_p'] = 90 - lat.attributes['CenterLat'][0]
             grid_info['o_lon_p'] = 180
             grid_info['lon_0'] = lat.attributes['CenterLon'][0] - 360
@@ -390,6 +389,10 @@ class fieldData(UPPData):
             val = lat.attributes[attr]
             val = val[0] if isinstance(val, np.ndarray) else val
             grid_info[bm_arg] = val
+
+        print('GRID_INFO')
+        for k, v in grid_info.items():
+            print(f'{k}: {v}')
 
         return grid_info
 

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -70,7 +70,7 @@
     clevs: !!python/object/apply:numpy.arange [5, 76, 5]
     cmap: NWSReflectivity
     colors: cref_colors
-    ncl_name: REFD_P0_L103_GLC0
+    ncl_name: REFD_P0_L103_{grid}
     ticks: 5
     title: 1 km agl Reflectivity
     unit: dBZ
@@ -80,7 +80,7 @@ acpcp: # Accumulated precipitation
     clevs: [0.01, 0.1, 0.25, 0.5, 1, 2, 3, 5, 10, 15, 20, 40]
     cmap: gist_ncar
     colors: accumulated_precip_colors
-    ncl_name: APCP_P8_L1_GLC0_acc{fhr}h
+    ncl_name: APCP_P8_L1_{grid}_acc{fhr}h
     ticks: 0
     transform:
       funcs: conversions.kgm2_to_in
@@ -90,7 +90,7 @@ acfrzr: # Run Total Freezing Rain
     clevs: [0.002, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2]
     cmap: gist_ncar
     colors: pcp_colors
-    ncl_name: FROZR_P8_L1_GLC0_acc{fhr}h
+    ncl_name: FROZR_P8_L1_{grid}_acc{fhr}h
     ticks: 0
     transform:
       funcs: conversions.kgm2_to_in
@@ -114,17 +114,16 @@ cape:
         alpha: 0
         hatches: ['///', '']
         levels: [50, 1000]
-    ncl_name: CAPE_P0_2L108_GLC0
+    ncl_name: CAPE_P0_2L108_{grid}
     ticks: 0
     title: Most Unstable CAPE
     unit: J/kg
     vertical_index: 2
-    vertical_level_name: lv_SPDL4_l0
   mul: # Most Unstable Layer CAPE
     <<: *cape
     contours:
     hatches:
-    ncl_name: CAPE_P0_2L108_GLC0
+    ncl_name: CAPE_P0_2L108_{grid}
     title: Most Unstable Layer CAPE
     vertical_index: 1
   mx90mb: # Lowest 90 mb Mixed Layer CAPE
@@ -140,7 +139,7 @@ cape:
         hatches: ['///', '']
         levels: [-1000, -50]
     vertical_index: 0
-    ncl_name: CAPE_P0_2L108_GLC0
+    ncl_name: CAPE_P0_2L108_{grid}
     title: Lowest 90 mb Mixed Layer CAPE
   sfc:
     <<: *cape
@@ -154,22 +153,22 @@ cape:
         alpha: 0
         hatches: ['///', '']
         levels: [-1000, -50]
-    ncl_name: CAPE_P0_L1_GLC0
+    ncl_name: CAPE_P0_L1_{grid}
     title: Surface CAPE
 cell: # Storm cell motion
   ua:
-    ncl_name: USTM_P0_2L103_GLC0
+    ncl_name: USTM_P0_2L103_{grid}
     transform:
       funcs: [vector_magnitude, conversions.ms_to_kt]
       kwargs:
-        field2: VSTM_P0_2L103_GLC0
+        field2: VSTM_P0_2L103_{grid}
     unit: kt
 ceil: # Ceiling
   ua: &ceil
     clevs: [0, 0.1, 0.3, 0.5, 1, 2, 3, 5, 10, 15, 20, 30, 52]
     cmap: gist_ncar
     colors: ceil_colors
-    ncl_name: HGT_P0_L215_GLC0
+    ncl_name: HGT_P0_L215_{grid}
     ticks: 0
     title: Ceiling
     transform:
@@ -181,37 +180,34 @@ ceil: # Ceiling
 ceilexp: # Ceiling - experimental
   ua:
     <<: *ceil
-    ncl_name: CEIL_P0_GLC0
+    ncl_name: CEIL_P0_{grid}
     title: Ceiling (exp)
 ceilexp2: # Ceiling - experimental no.2
   ua:
     <<: *ceil
-    ncl_name: CEIL_P0_L2_GLC0
+    ncl_name: CEIL_P0_L2_{grid}
     title: Ceiling (exp-2)
 cin: # Surface Convective Inhibition
   mu:
     clevs: [-300, -200, -150, -100, -75, -50, -40, -30, -20, -10, -1]
     cmap: gist_ncar
     colors: cin_colors
-    ncl_name: CIN_P0_2L108_GLC0
+    ncl_name: CIN_P0_2L108_{grid}
     unit: J/kg
     vertical_index: 2
-    vertical_level_name: lv_SPDL4_l0
   mx90mb: # Lowest 90 mb Mixed Layer CIN
-    ncl_name: CIN_P0_2L108_GLC0
+    ncl_name: CIN_P0_2L108_{grid}
     title: 'ML CIN < -50'
     vertical_index: 0
-    vertical_level_name: lv_SPDL4_l0
   sfc: &sfc_cin
     clevs: [-300, -200, -150, -100, -75, -50, -40, -30, -20, -10, -1]
     cmap: gist_ncar
     colors: cin_colors
-    ncl_name: CIN_P0_L1_GLC0
+    ncl_name: CIN_P0_L1_{grid}
     ticks: 0
     title: Surface CIN
     unit: J/kg
     vertical_index: 2
-    vertical_level_name: lv_SPDL4_l0
   sfclt:
     <<: *sfc_cin
     title: Surface CIN < -50
@@ -220,7 +216,7 @@ cloudcover:
     clevs: [2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95]
     cmap: gist_ncar
     colors: cldcov_colors
-    ncl_name: TCDC_P0_L211_GLC0
+    ncl_name: TCDC_P0_L211_{grid}
     ticks: 0
     title: PBL ... 1km Cloud Cover
     unit: '%'
@@ -229,33 +225,33 @@ cloudcover:
     clevs: [2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95]
     cmap: gist_ncar
     colors: cldcov_colors
-    ncl_name: HCDC_P0_L234_GLC0
+    ncl_name: HCDC_P0_L234_{grid}
     ticks: 0
     title: High-Level Cloud Cover
     unit: '%'
   low:
     <<: *cld_cover
-    ncl_name: LCDC_P0_L214_GLC0
+    ncl_name: LCDC_P0_L214_{grid}
     title: Low-Level Cloud Cover
   mid:
     <<: *cld_cover
-    ncl_name: MCDC_P0_L224_GLC0
+    ncl_name: MCDC_P0_L224_{grid}
     title: Mid-Level Cloud Cover
   total:
     <<: *cld_cover
-    ncl_name: TCDC_P0_L10_GLC0
+    ncl_name: TCDC_P0_L10_{grid}
     title: Total Cloud Cover
 cref: # Composite reflectivity
   sfc:
     <<: *refl
-    ncl_name: REFC_P0_L10_GLC0
+    ncl_name: REFC_P0_L10_{grid}
     title: Composite Reflectivity
 cpofp: # Frozen Precipitation Percentage
   sfc:
     clevs: [-0.1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
     cmap: gist_ncar
     colors: frzn_colors
-    ncl_name: CPOFP_P0_L1_GLC0
+    ncl_name: CPOFP_P0_L1_{grid}
     ticks: 0
     title: Frozen Precip Percentage
     unit: '%'
@@ -264,7 +260,7 @@ ctop: # Cloud top height
     clevs: !!python/object/apply:numpy.arange [0, 61, 5]
     cmap: gist_ncar
     colors: ceil_colors
-    ncl_name: HGT_P0_L3_GLC0
+    ncl_name: HGT_P0_L3_{grid}
     ticks: 0
     title: Cloud Top Height
     transform: conversions.m_to_kft
@@ -274,7 +270,7 @@ dewp: # Dew point temperature
     clevs: [-60, -50, -40, -30, -20, -10, 0, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 80, 90, 100, 110, 120]
     cmap: Carbone42_r
     colors: dewp_colors
-    ncl_name: DPT_P0_L103_GLC0
+    ncl_name: DPT_P0_L103_{grid}
     ticks: -4
     transform: conversions.k_to_f
     unit: F
@@ -284,7 +280,7 @@ echotop: # Echo Top
     clevs: !!python/object/apply:numpy.arange [4, 50, 3]
     cmap: NWSReflectivity
     colors: cref_colors
-    ncl_name: RETOP_P0_L3_GLC0
+    ncl_name: RETOP_P0_L3_{grid}
     ticks: 0
     title: Echo Top
     transform: conversions.m_to_kft
@@ -294,7 +290,7 @@ G113bt: # GOES-W Brightness temperature, water vapor (Ch 3)
     clevs: !!python/object/apply:numpy.arange [-80, 41, 1]
     cmap: WVCIMSS_r
     colors: goes_colors
-    ncl_name: SBT113_P0_L8_GLC0
+    ncl_name: SBT113_P0_L8_{grid}
     ticks: -10
     title: GOES-W Brightness Temperature, Water Vapor
     transform: conversions.k_to_c
@@ -302,18 +298,18 @@ G113bt: # GOES-W Brightness temperature, water vapor (Ch 3)
 G114bt: # GOES-W Brightness temperature, infrared (Ch 4)
   sat:
     <<: *goes_sat
-    ncl_name: SBT114_P0_L8_GLC0
+    ncl_name: SBT114_P0_L8_{grid}
     title: GOES-W Brightness Temperature, Infrared
     unit: ch 4
 G123bt: # GOES-E Brightness temperature, water vapor (Ch 3)
   sat:
     <<: *goes_sat
-    ncl_name: SBT123_P0_L8_GLC0
+    ncl_name: SBT123_P0_L8_{grid}
     title: GOES-E Brightness Temperature, Water Vapor
 G124bt: # GOES-E Brightness temperature, infrared (Ch 4)
   sat:
     <<: *goes_sat
-    ncl_name: SBT124_P0_L8_GLC0
+    ncl_name: SBT124_P0_L8_{grid}
     title: GOES-E Brightness Temperature, Infrared
     unit: ch 4
 gh: # Geopotential height
@@ -322,8 +318,8 @@ gh: # Geopotential height
     cmap: precipitation
     colors: terrain_colors
     ncl_name:
-      prs: HGT_P0_L100_GLC0
-      nat: HGT_P0_L105_GLC0
+      prs: HGT_P0_L100_{grid}
+      nat: HGT_P0_L105_{grid}
     ticks: 4
     transform: conversions.m_to_dm
     unit: dm
@@ -342,7 +338,7 @@ gh: # Geopotential height
     <<: *ua_gh
     clevs: !!python/object/apply:numpy.arange [0, 5000, 250]
     cmap: gist_earth
-    ncl_name: HGT_P0_L1_GLC0
+    ncl_name: HGT_P0_L1_{grid}
     ticks: 0
     transform: []
     unit: gpm
@@ -353,7 +349,7 @@ gust:
     clevs: !!python/object/apply:numpy.arange [5, 95, 5]
     cmap: gist_ncar
     colors: wind_colors
-    ncl_name: GUST_P0_L1_GLC0
+    ncl_name: GUST_P0_L1_{grid}
     ticks: 5
     transform: conversions.ms_to_kt
     unit: kt
@@ -362,121 +358,110 @@ hail: # Max 1h Hail diameter
     clevs: [0.01, 0.25, 0.50, 0.75, 1.0, 1.5, 2.0, 2.5, 3.0]
     cmap: gist_ncar
     colors: hail_colors
-    ncl_name: HAIL_P8_L104_GLC0_max1h
+    ncl_name: HAIL_P8_L104_{grid}_max1h
     ticks: 0
     title: Max 1h Hail/Graupel Diameter at Surface
     transform: conversions.m_to_in
     unit: in
   max: # total atmosphere
     <<: *hail
-    ncl_name: HAIL_P8_L10_GLC0_max1h
+    ncl_name: HAIL_P8_L10_{grid}_max1h
     title: Max 1h Hail/Graupel Diameter, Total Atm
 hailcast: # Max 1h Hail diameter
   maxsfc: # surface, from HAILCAST
     <<: *hail
-    ncl_name: HAIL_P8_L1_GLC0_max1h
+    ncl_name: HAIL_P8_L1_{grid}_max1h
     title: Max 1h Hail Diameterat Sfc from HAILCAST
 hlcy: # Helicity
   in16: &hlcy # Hourly updraft helicity over 1-6 km layer
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
     cmap: gist_ncar
     colors: hlcy_colors
-    ncl_name: UPHL_P0_2L103_GLC0
+    ncl_name: UPHL_P0_2L103_{grid}
     ticks: 25
     title: 1-6km Updraft Helicity
     unit: m2/s2
     vertical_index: 1
-    vertical_level_name: lv_HTGL6_l0
   in25: # Hourly updraft helicity over 2-5 km layer
     <<: *hlcy 
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    ncl_name: UPHL_P0_2L103_GLC0
+    ncl_name: UPHL_P0_2L103_{grid}
     title: 2-5km Updraft Helicity
     vertical_index: 0
   mn02: # Hourly minimum of updraft helicity over 0-2 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
-    ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
+    ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
     ticks: 12.5
     title: 0-2km Min Updraft Helicity (over prv hr)
     vertical_index: 0
-    vertical_level_name: lv_HTGL12_l0
   mn03: # Hourly minimum of updraft helicity over 0-3 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
-    ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
+    ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
     ticks: 12.5
     title: 0-3km Min Updraft Helicity (over prv hr)
     vertical_index: 1
-    vertical_level_name: lv_HTGL12_l0
   mn16: # Hourly minimum of updraft helicity over 1-6 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
+    ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
     title: 1-6km Min Updraft Helicity (over prv hr)
     vertical_index: 3
-    vertical_level_name: lv_HTGL12_l0
   mn25: # Hourly minimum of updraft helicity over 2-5 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    ncl_name: VAR_0_7_200_P8_2L103_GLC0_min1h
+    ncl_name: VAR_0_7_200_P8_2L103_{grid}_min1h
     title: 2-5km Min Updraft Helicity (over prv hr)
     vertical_index: 2
-    vertical_level_name: lv_HTGL12_l0
   mx02: # Hourly maximum of updraft helicity over 0-2 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
-    ncl_name: MXUPHL_P8_2L103_GLC0_max1h
+    ncl_name: MXUPHL_P8_2L103_{grid}_max1h
     ticks: 12.5
     title: 0-2km Max Updraft Helicity (over prv hr)
     vertical_index: 0
-    vertical_level_name: lv_HTGL12_l1
   mx03: # Hourly maximum of updraft helicity over 0-3 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [12.5, 150.5, 12.5]
-    ncl_name: MXUPHL_P8_2L103_GLC0_max1h
+    ncl_name: MXUPHL_P8_2L103_{grid}_max1h
     ticks: 12.5
     title: 0-3km Max Updraft Helicity (over prv hr)
     vertical_index: 1
-    vertical_level_name: lv_HTGL12_l0
   mx16: # Hourly maximum of updraft helicity over 1-6 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    ncl_name: MXUPHL_P8_2L103_GLC0_max1h
+    ncl_name: MXUPHL_P8_2L103_{grid}_max1h
     title: 1-6km Max Updraft Helicity (over prv hr)
     vertical_index: 3
-    vertical_level_name: lv_HTGL12_l0
   mx25: # Hourly maximum of updraft helicity over 2-5 km layer
     <<: *hlcy
     clevs: !!python/object/apply:numpy.arange [25, 301, 25]
-    ncl_name: MXUPHL_P8_2L103_GLC0_max1h
+    ncl_name: MXUPHL_P8_2L103_{grid}_max1h
     title: 2-5km Max Updraft Helicity (over prv hr)
     vertical_index: 2
-    vertical_level_name: lv_HTGL12_l0
   sr01: # 0-1 km Storm Relative Helicity
     <<: *hlcy
     clevs: [25, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800]
-    ncl_name: HLCY_P0_2L103_GLC0
+    ncl_name: HLCY_P0_2L103_{grid}
     unit: $m^2 / s^2$
     ticks: 0
     title: 0-1 km Storm Relative Helicity
     vertical_index: 0
-    vertical_level_name: lv_HTGL5_l0
   sr03: # 0-3 km Storm Relative Helicity
     <<: *hlcy
     clevs: [25, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800]
-    ncl_name: HLCY_P0_2L103_GLC0
+    ncl_name: HLCY_P0_2L103_{grid}
     unit: $m^2 / s^2$
     ticks: 0
     title: 0-3 km Storm Relative Helicity
     vertical_index: 1
-    vertical_level_name: lv_HTGL5_l0
 hpbl: # Height of Planetary Boundary Layer
   sfc: 
     clevs: [25, 50, 100, 200, 300, 500, 750, 1000, 1500, 2000, 2500, 3000, 4000, 5000]
     cmap: ir_rgbv
     colors: pbl_colors
-    ncl_name: HPBL_P0_L1_GLC0
+    ncl_name: HPBL_P0_L1_{grid}
     ticks: 0
     title: PBL Height
     unit: m
@@ -490,7 +475,7 @@ lcl: # Lifted condensation level
         colors: white
         levels: [1000, 100000]
         linewidths: 1.2
-    ncl_name: HGT_P0_L5_GLC0
+    ncl_name: HGT_P0_L5_{grid}
     ticks: -2
     title: Lifted Condensation Level Height
     unit: m agl
@@ -502,7 +487,7 @@ lhtfl: # Latent Heat Net Flux
     clevs: !!python/object/apply:numpy.arange [-100, 401, 25]
     cmap: Carbone42
     colors: heat_flux_colors
-    ncl_name: LHTFL_P0_L1_GLC0
+    ncl_name: LHTFL_P0_L1_{grid}
     ticks: 0
     title: Latent Heat Net Flux
     unit: W/m^2
@@ -511,17 +496,17 @@ li: # Lifted Index
     clevs: !!python/object/apply:numpy.arange [-15, 16]
     cmap: Spectral
     colors: lifted_index_colors
-    ncl_name: 4LFTX_P0_2L108_GLC0
+    ncl_name: 4LFTX_P0_2L108_{grid}
     ticks: 0
     title: Best Lifted Index (lowest 180 mb)
     unit: C
   sfc:
     <<: *lifted_index
-    ncl_name: LFTX_P0_2L100_GLC0
+    ncl_name: LFTX_P0_2L100_{grid}
     title: Surface Lifted Index
 lpl: # Lifted parcel level
   agl:
-    ncl_name: PLPL_P0_2L108_GLC0
+    ncl_name: PLPL_P0_2L108_{grid}
     title: Lifted Parcel Level AGL >50
     transform:
       funcs: [conversions.pa_to_hpa, field_diff, opposite]
@@ -530,7 +515,7 @@ lpl: # Lifted parcel level
         level2: sfc
     unit: hPa
   ua:
-    ncl_name: PLPL_P0_2L108_GLC0
+    ncl_name: PLPL_P0_2L108_{grid}
     transform: conversions.pa_to_hpa
     unit: hPa
 ltg3: # Lightning Threat (LTG1 ... LTG2)
@@ -538,21 +523,21 @@ ltg3: # Lightning Threat (LTG1 ... LTG2)
     clevs: [0.02, 0.5, 1.0, 1.5, 2.0, 2.5, 3, 4, 5, 6, 7, 8, 10, 12]
     cmap: NWSReflectivity
     colors: cref_colors
-    ncl_name: LTNG_P0_L10_GLC0
+    ncl_name: LTNG_P0_L10_{grid}
     ticks: 0
     title: Lightning Threat (comb of LTG1 and LTG2)
     unit: flashes / km^2 / 5 min
 mref: # Maximum reflectivity for past hour at 1 km AGL
   sfc:
     <<: *refl
-    ncl_name: MAXREF_P8_L103_GLC0_max1h
+    ncl_name: MAXREF_P8_L103_{grid}_max1h
     title: Max 1km agl Reflectivity (over prev hr)
 pres:
   sfc:
     clevs: !!python/object/apply:numpy.arange [650, 1051, 4]
     cmap: gist_ncar
     colors: ps_colors
-    ncl_name: PRES_P0_L1_GLC0
+    ncl_name: PRES_P0_L1_{grid}
     ticks: 20
     transform: conversions.pa_to_hpa
     unit: hPa
@@ -560,18 +545,18 @@ pres:
     clevs: !!python/object/apply:numpy.arange [650, 1051, 4]
     cmap: gist_ncar
     colors: ps_colors
-    ncl_name: MSLMA_P0_L101_GLC0
+    ncl_name: MSLMA_P0_L101_{grid}
     ticks: 20
     transform: conversions.pa_to_hpa
     unit: hPa
   ua:
-    ncl_name: PRES_P0_L105_GLC0
+    ncl_name: PRES_P0_L105_{grid}
 ptmp: # Potential temperature
   2m:
     clevs: !!python/object/apply:numpy.arange [210, 350, 5]
     cmap: jet
     colors: t_colors
-    ncl_name: POT_P0_L103_GLC0
+    ncl_name: POT_P0_L103_{grid}
     ticks: 10
     unit: K
     wind: 10m
@@ -580,29 +565,29 @@ pwtr: # Precipitable water
     clevs: !!python/object/apply:numpy.arange [4, 81, 4]
     cmap: gist_ncar
     colors: pw_colors
-    ncl_name: PWAT_P0_L200_GLC0
+    ncl_name: PWAT_P0_L200_{grid}
     ticks: 4
     unit: mm
 ref: # Maximum reflectivity for past hour at 1 km AGL
   m10:
     <<: *refl
-    ncl_name: REFD_P0_L20_GLC0
+    ncl_name: REFD_P0_L20_{grid}
     title: -10C Isothermal Reflectivity
   maxm10:
     <<: *refl
-    ncl_name: REFD_P8_L20_GLC0_max1h
+    ncl_name: REFD_P8_L20_{grid}_max1h
     title: Max 1h -10C Isothermal Reflectivity
 rh: # Relative Humidity
   2m: &rh
     clevs: [10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100, 105]
     cmap: gist_ncar
     colors: rh_colors
-    ncl_name: RH_P0_L103_GLC0
+    ncl_name: RH_P0_L103_{grid}
     ticks: 10
     unit: '%'
   500mb: &rh_ua
     <<: *rh
-    ncl_name: RH_P0_L100_GLC0
+    ncl_name: RH_P0_L100_{grid}
     contours:
       pres_sfc:
         colors: 'k'
@@ -639,14 +624,14 @@ rh: # Relative Humidity
         levels: [0, 850]
   pw: # RH wrt Precipitable Water
     <<: *rh
-    ncl_name: RHPW_P0_L10_GLC0
+    ncl_name: RHPW_P0_L10_{grid}
     title: Relative Humidity wrt Precipitable Water
 rvil: # Radar-derived Vertically Integrated Liquid
   sfc: &vert_int_liq
     clevs: [0.05, 0.15, 0.76, 3.47, 6.92, 12, 31.6, 35, 40, 45, 50, 55, 60, 65, 70]
     cmap: NWSReflectivity
     colors: cref_colors
-    ncl_name: VIL_P0_L10_GLC0
+    ncl_name: VIL_P0_L10_{grid}
     ticks: 0
     title: Radar-derived Vertically Integrated Liquid
     unit: kg/m^2
@@ -655,30 +640,29 @@ shear:
     clevs: !!python/object/apply:numpy.arange [5, 91, 5]
     cmap: jet
     colors: shear_colors
-    ncl_name: VUCSH_P0_2L103_GLC0
+    ncl_name: VUCSH_P0_2L103_{grid}
     transform:
       funcs: vector_magnitude
       kwargs:
-        field2: VVCSH_P0_2L103_GLC0
+        field2: VVCSH_P0_2L103_{grid}
         one_lev: True
         vertical_index: 0
     ticks: 0
     unit: $s^{-1}$
     vertical_index: 0
-    vertical_level_name: lv_HTGL2_l1
   06km: # 0-6 km
     <<: *shear
     transform:
       funcs: vector_magnitude
       kwargs:
-        field2: VVCSH_P0_2L103_GLC0
+        field2: VVCSH_P0_2L103_{grid}
         one_lev: True
         vertical_index: 1
     vertical_index: 1
 shtfl: # Sensible Heat Net Flux
   sfc:
     <<: *heat_flux
-    ncl_name: SHTFL_P0_L1_GLC0
+    ncl_name: SHTFL_P0_L1_{grid}
     ticks: 0
     title: Sensible Heat Net Flux
     unit: W/m^2
@@ -687,7 +671,7 @@ soilm: # Soil Moisture Availability
     clevs: [0, 5, 15, 25, 35, 45, 55, 65, 75, 85, 95]
     cmap: Spectral
     colors: soilm_colors
-    ncl_name: MSTAV_P0_L106_GLC0
+    ncl_name: MSTAV_P0_L106_{grid}
     ticks: 0
     title: Soil Moisture Availability
     unit: "%"
@@ -696,7 +680,7 @@ soilt: # Soil Temperature
     clevs: !!python/object/apply:numpy.arange [240, 311, 10]
     cmap: gist_ncar
     colors: soilt_colors
-    ncl_name: TSOIL_P0_2L106_GLC0
+    ncl_name: TSOIL_P0_2L106_{grid}
     ticks: 0
     title: Soil Temperature at Sfc
     unit: K
@@ -730,7 +714,7 @@ soilw: # Soil Moisture
     clevs: !!python/object/apply:numpy.arange [0.0, 0.61, 0.1]
     cmap: gist_ncar
     colors: soilw_colors
-    ncl_name: SOILW_P0_2L106_GLC0
+    ncl_name: SOILW_P0_2L106_{grid}
     ticks: 0
     title: Soil Moisture at Sfc
     unit: fraction
@@ -764,19 +748,19 @@ solar: # Incoming Solar Radiation
     clevs: [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100]
     cmap: gist_ncar
     colors: vort_colors
-    ncl_name: DSWRF_P0_L1_GLC0
+    ncl_name: DSWRF_P0_L1_{grid}
     ticks: 0
     title: Incoming Solar Radiation
     unit: W/m^2
 sphum: # Specific humidity
   ua:
-    ncl_name: SPFH_P0_L105_GLC0
+    ncl_name: SPFH_P0_L105_{grid}
 ssrun: # Storm Surface Runoff
   sfc: &precip
     clevs: [0.002, 0.01, 0.05, 0.1, 0.25, 0.50, 0.75, 1.0, 2.0]
     cmap: gist_ncar
     colors: pcp_colors
-    ncl_name: SSRUN_P8_L1_GLC0_acc1h
+    ncl_name: SSRUN_P8_L1_{grid}_acc1h
     ticks: 0
     title: Storm Surface Runoff
     transform: conversions.kgm2_to_in
@@ -786,7 +770,7 @@ temp: # Temperature
     clevs: !!python/object/apply:numpy.arange [-16, 17, 2]
     cmap: seismic
     colors: centered_diff
-    ncl_name: TMP_P0_L103_GLC0 # 2m Temp
+    ncl_name: TMP_P0_L103_{grid} # 2m Temp
     ticks: 2
     title: 2m Temp - Skin Temp
     transform:
@@ -800,7 +784,7 @@ temp: # Temperature
     clevs: !!python/object/apply:numpy.arange [-60, 120, 10]
     cmap: jet
     colors: t_colors
-    ncl_name: TMP_P0_L103_GLC0
+    ncl_name: TMP_P0_L103_{grid}
     ticks: 10
     transform: conversions.k_to_f
     unit: F
@@ -822,8 +806,8 @@ temp: # Temperature
         hatches: ['...', '']
         levels: [0, 500]
     ncl_name:
-      prs: TMP_P0_L100_GLC0
-      nat: TMP_P0_L105_GLC0
+      prs: TMP_P0_L100_{grid}
+      nat: TMP_P0_L105_{grid}
     ticks: 5
     transform: conversions.k_to_c
     unit: C
@@ -844,8 +828,8 @@ temp: # Temperature
         hatches: ['...', '']
         levels: [0, 700]
     ncl_name:
-      prs: TMP_P0_L100_GLC0
-      nat: TMP_P0_L105_GLC0
+      prs: TMP_P0_L100_{grid}
+      nat: TMP_P0_L105_{grid}
     ticks: 5
     transform: conversions.k_to_c
     unit: C
@@ -880,7 +864,7 @@ temp: # Temperature
     clevs: !!python/object/apply:numpy.arange [-60, 120, 10]
     cmap: jet
     colors: t_colors
-    ncl_name: TMP_P0_L1_GLC0
+    ncl_name: TMP_P0_L1_{grid}
     ticks: 20
     transform: conversions.k_to_f
     unit: F
@@ -908,16 +892,16 @@ totp: # Hourly total precipitation
         levels: !!python/object/apply:numpy.arange [402, 601, 6]
         linewidths: 0.8
         linestyles: dashed
-    ncl_name: APCP_P8_L1_GLC0_acc1h
+    ncl_name: APCP_P8_L1_{grid}_acc1h
     title: 1 hr Total Precip
 u:
   10m:
-    ncl_name: UGRD_P0_L103_GLC0
+    ncl_name: UGRD_P0_L103_{grid}
     transform: conversions.ms_to_kt
   500mb: &ua_uwind
     ncl_name:
-      prs: UGRD_P0_L100_GLC0
-      nat: UGRD_P0_L105_GLC0
+      prs: UGRD_P0_L100_{grid}
+      nat: UGRD_P0_L105_{grid}
   700mb: *ua_uwind
   850mb: *ua_uwind
   925mb: *ua_uwind
@@ -928,7 +912,7 @@ ulwrf: # Upward Longwave Radiation Flux
     clevs: !!python/object/apply:numpy.arange [350, 601, 10]
     cmap: gist_ncar
     colors: radiation_colors
-    ncl_name: ULWRF_P0_L1_GLC0
+    ncl_name: ULWRF_P0_L1_{grid}
     ticks: 0
     title: Upward Longwave Radiation Flux, Surface
     unit: W/m^2
@@ -936,31 +920,31 @@ ulwrf: # Upward Longwave Radiation Flux
     clevs: !!python/object/apply:numpy.arange [80, 341, 2]
     cmap: ir_rgbv_r
     colors: radiation_mix_colors
-    ncl_name: ULWRF_P0_L8_GLC0
+    ncl_name: ULWRF_P0_L8_{grid}
     ticks: 20
     title: Outgoing Longwave Radiation Flux, Top of Atmosphere
     unit: W/m^2
 uswrf: # Upward Shortwave Radiation Flux
   sfc:
     <<: *radiation_flux
-    ncl_name: USWRF_P0_L1_GLC0
+    ncl_name: USWRF_P0_L1_{grid}
     title: Upward Shortwave Radiation Flux, Surface
   top: # Nominal top of atmosphere
     <<: *radiation_flux
     clevs: !!python/object/apply:numpy.arange [50, 851, 10]
     cmap: Greys_r
     colors: radiation_bw_colors
-    ncl_name: USWRF_P0_L8_GLC0
+    ncl_name: USWRF_P0_L8_{grid}
     ticks: 40
     title: Outgoing Shortwave Radiation Flux, Top of Atmosphere
 v:
   10m:
-    ncl_name: VGRD_P0_L103_GLC0
+    ncl_name: VGRD_P0_L103_{grid}
     transform: conversions.ms_to_kt
   500mb: &ua_vwind
     ncl_name:
-      prs: VGRD_P0_L100_GLC0
-      nat: VGRD_P0_L105_GLC0
+      prs: VGRD_P0_L100_{grid}
+      nat: VGRD_P0_L105_{grid}
     transform: conversions.ms_to_kt
   700mb: *ua_vwind
   850mb: *ua_vwind
@@ -970,24 +954,24 @@ v:
 vbdsf: # Incoming Direct Radiation
   sfc:
     <<: *incoming_radiation
-    ncl_name: VBDSF_P0_L1_GLC0
+    ncl_name: VBDSF_P0_L1_{grid}
     title: Incoming Direct Radiation
 vddsf: # Incoming Diffuse Radiation
   sfc:
     <<: *incoming_radiation
-    ncl_name: VDDSF_P0_L1_GLC0
+    ncl_name: VDDSF_P0_L1_{grid}
     title: Incoming Diffuse Radiation
 vil: # Vertically Integrated Liquid
   sfc:
     <<: *vert_int_liq
-    ncl_name: VAR_0_16_201_P0_L10_GLC0
+    ncl_name: VAR_0_16_201_P0_L10_{grid}
     title: Vertically Integrated Liquid
 vig: # Vertically-integrated graupel
   sfc:
     clevs: !!python/object/apply:numpy.arange [5, 91, 5]
     cmap: jet
     colors: graupel_colors
-    ncl_name: TCOLG_P8_L200_GLC0_max1h
+    ncl_name: TCOLG_P8_L200_{grid}_max1h
     ticks: 0
     title: Max Vertically Integrated Graupel (over previous hour)
     unit: mm
@@ -996,7 +980,7 @@ vis: # Visibility
     clevs: [0.0625, 0.125, 0.25, 0.5, 1, 1.5, 2, 3, 4, 5, 10, 30, 50]
     cmap: gist_ncar
     colors: vis_colors
-    ncl_name: VIS_P0_L1_GLC0
+    ncl_name: VIS_P0_L1_{grid}
     ticks: 0
     title: Sfc Visibility
     transform: conversions.m_to_mi
@@ -1009,7 +993,7 @@ vort: # Absolute vorticity
     contours:
       gh:
         colors: 'xkcd:light gray'
-    ncl_name: ABSV_P0_L100_GLC0
+    ncl_name: ABSV_P0_L100_{grid}
     ticks: 2
     transform: conversions.vort_scale
     unit: 1E-5/s
@@ -1021,7 +1005,7 @@ vvel: # Vertical velocity
     contours:
       gh:
         colors: grey
-    ncl_name: VVEL_P0_L100_GLC0
+    ncl_name: VVEL_P0_L100_{grid}
     ticks: 5
     transform: conversions.vvel_scale
     unit: -Pa/s * 10
@@ -1030,7 +1014,7 @@ vvel: # Vertical velocity
 #    cmap: nipy_spectral
     cmap: Spectral_r
     colors: mean_vvel_colors
-    ncl_name: DZDT_P8_2L104_GLC0_avg1h
+    ncl_name: DZDT_P8_2L104_{grid}_avg1h
     ticks: 0
     title: Mean Vertical Velocity, sigma layers 0.5-0.8
     unit: m/s
@@ -1039,7 +1023,7 @@ vvort: # Vertical vorticity
     clevs: !!python/object/apply:numpy.arange [0.0025, 0.0301, 0.0025]
     cmap: gist_ncar
     colors: vort_colors
-    ncl_name: RELV_P8_2L103_GLC0_max1h
+    ncl_name: RELV_P8_2L103_{grid}_max1h
     ticks: 0
     title: 0-1km Max Vertical Velocity (over prev hour)
     unit: 1/s
@@ -1052,7 +1036,7 @@ weasd: # Water equivalent of accumulated snow depth
     clevs: [0.01, 0.1, 0.3, 0.5, 1, 2, 3, 4, 5, 7.5, 10, 20]
     cmap: gist_ncar
     colors: accumulated_precip_colors
-    ncl_name: WEASD_P8_L1_GLC0_acc{fhr}h
+    ncl_name: WEASD_P8_L1_{grid}_acc{fhr}h
     ticks: 0
     title: Snow Water Equivalent
     transform:

--- a/adb_graphics/default_specs.yml
+++ b/adb_graphics/default_specs.yml
@@ -70,7 +70,7 @@
     clevs: [0.03, 0.05, 0.1, 0.5, 1, 2, 3, 4, 5, 6, 7, 8]
     cmap: gist_ncar
     colors: snow_colors
-    ncl_name: WEASD_P8_L1_GLC0_acc1h
+    ncl_name: WEASD_P8_L1_{grid}_acc1h
     ticks: 0
     title: 1 hr Accumulated Snow Using 10:1 Ratio
     transform: [conversions.kgm2_to_in, conversions.weasd_to_1hsnw]
@@ -125,7 +125,6 @@ acsnw: # Run Total Accumulated Snow Using 10:1 Ratio
     cmap: gist_ncar
     colors: snow_colors
     ncl_name: WEASD_P8_L1_{grid}_acc{fhr}h
-    ncl_name: WEASD_P8_L1_GLC0_acc{fhr}h
     ticks: 0
     title: Run-Total Accumulated Snow Using 10:1 Ratio
     transform: [conversions.kgm2_to_in, conversions.weasd_to_1hsnw]

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -28,6 +28,7 @@ TILE_DEFS = {
     'SC': [24, 41, -107, -86],
     'SE': [22, 37, -93.5, -72],
     'SW': [24.5, 45, -122, -103],
+    'AKZoom': [52, 73, -162, -132],
     'ATL': [31.2, 35.8, -87.4, -79.8],
     'CA-NV': [30, 45, -124, -114],
     'CentralCA': [34.5, 40.5, -124, -118],
@@ -391,17 +392,32 @@ class DataMap():
 
         u, v = self.field.wind(level)
 
-        # Set the stride of the barbs to be plotted with a masked array.
+        tile = self.map.tile
+
+        # Set the stride and size of the barbs to be plotted with a masked array.
+        if self.map.m.projection == 'lcc' and tile == 'full':
+            stride = 30
+            length = 5
+        elif tile == 'HI':
+            stride = 1
+            length = 4
+        elif len(tile) == 2 or tile in ['full', 'conus', 'GreatLakes', 'CA-NV']:
+            stride = 10
+            length = 4
+        else:
+            stride = 4
+            length = 4
+
         mask = np.ones_like(u)
-        mask[::30, ::35] = 0
+        mask[::stride, ::stride] = 0
 
         mu, mv = [np.ma.masked_array(c, mask=mask) for c in [u, v]]
         x, y = self._xy_mesh(self.field)
         self.map.m.barbs(x, y, mu, mv,
                          barbcolor='k',
                          flagcolor='k',
-                         length=6,
-                         linewidth=0.3,
+                         length=length,
+                         linewidth=0.2,
                          sizes={'spacing': 0.25},
                          )
 

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -35,6 +35,7 @@ TILE_DEFS = {
     'DCArea': [36.7, 40, -81, -72],
     'EastCO': [36.5, 41.5, -108, -101.8],
     'GreatLakes': [37, 50, -95, -70],
+    'HI': [16.6, 24.6, -157.6, -157.5],
     'NYC-BOS': [40, 43, -78.5, -68.5],
     'SEA-POR': [43, 50, -125, -119],
     'SouthCA': [31, 37, -120, -114],
@@ -73,21 +74,23 @@ class Map():
         self.tile = kwargs.get('tile', 'full')
         self.airports = self.load_airports(airport_fn)
 
-        # Set the corners of the domain, either explicitly, or by tile label
-        self.corners = kwargs.get('corners')
-
         if self.tile == 'full':
             self.corners = self.grid_info.pop('corners')
         else:
             self.corners = self.get_corners()
             self.grid_info.pop('corners')
 
-        self.m = self._get_basemap(**self.grid_info)
+        # Some of Hawaii's smaller islands don't show up with a larger
+        # threshold.
+        area_thresh = 1000
+        if self.tile == 'HI':
+            area_thresh = 100
+
+        self.m = self._get_basemap(area_thresh=area_thresh, **self.grid_info)
 
     def boundaries(self):
 
         ''' Draws map boundaries - coasts, states, countries. '''
-
 
         try:
             self.m.drawcoastlines(linewidth=0.5)
@@ -103,7 +106,6 @@ class Map():
                                     linewidth=0.1,
                                     zorder=2,
                                     )
-
         self.m.drawstates()
         self.m.drawcountries()
 
@@ -135,7 +137,6 @@ class Map():
         ''' Wrapper around basemap creation '''
 
         basemap_args = dict(
-            area_thresh=1000,
             ax=self.ax,
             resolution='i',
             )

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -50,8 +50,8 @@ class Map():
     def __init__(self, airport_fn, ax, **kwargs):
 
         self.ax = ax
-        self.corners = kwargs.get('corners', REGIONS[kwargs.get('region', 'hrrr')])
-        self.m = self._get_basemap(**kwargs.get('map_proj', {}))
+        self.grid_info = kwargs.get('grid_info', {})
+        self.m = self._get_basemap(**self.grid_info)
         self.airports = self.load_airports(airport_fn)
 
     def boundaries(self):
@@ -85,22 +85,29 @@ class Map():
                     markersize=4,
                     )
 
-    def _get_basemap(self, center_lat=39.0, center_lon=262.5, lat_1=38.5, lat_2=38.5):
+    def _get_basemap(self, **get_basemap_kwargs):
 
         ''' Wrapper around basemap creation '''
 
-        return Basemap(ax=self.ax,
-                       lat_0=center_lat,
-                       lat_1=lat_1,
-                       lat_2=lat_2,
-                       llcrnrlat=self.corners[0],
-                       llcrnrlon=self.corners[2],
-                       lon_0=center_lon,
-                       projection='lcc',
-                       resolution='l',
-                       urcrnrlat=self.corners[1],
-                       urcrnrlon=self.corners[3],
-                       )
+        basemap_args = dict(ax=self.ax,
+                            resolution='l',
+                            )
+        corners = get_basemap_kwargs.pop('corners', None)
+        if corners is not None:
+            basemap_args.update(dict(
+                llcrnrlat=corners[0],
+                llcrnrlon=corners[2],
+                urcrnrlat=corners[1],
+                urcrnrlon=corners[3],
+                ))
+
+        basemap_args.update(get_basemap_kwargs)
+
+        print('BASEMAP ARGS')
+        for k,v in basemap_args.items():
+            print(f'{k}: {v}')
+
+        return Basemap(**basemap_args)
 
     @staticmethod
     def load_airports(fn):

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -74,7 +74,7 @@ class Map():
         self.tile = kwargs.get('tile', 'full')
         self.airports = self.load_airports(airport_fn)
 
-        if self.tile in ['full', 'conus']:
+        if self.tile in ['full', 'conus', 'AK',]:
             self.corners = self.grid_info.pop('corners')
         else:
             self.corners = self.get_corners()
@@ -100,7 +100,7 @@ class Map():
                                 zorder=2,
                                 )
         else:
-            if self.tile not in ['full', 'conus']:
+            if self.tile not in ['full', 'conus', 'AK']:
                 self.m.drawcounties(antialiased=False,
                                     color='gray',
                                     linewidth=0.1,

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -22,19 +22,19 @@ import adb_graphics.utils as utils
 #     Order: [lower left lat, upper right lat, lower left lon, upper right lon]
 
 TILE_DEFS = {
-    'NC': [37, 49, -108, -86],
-    'NE': [36, 47.5, -91, -64.5],
-    'NW': [37, 52, -125, -104],
-    'SC': [25, 42, -106.5, -88],
-    'SE': [25, 37, -93.5, -74],
-    'SW': [24.5, 45, -122, -104],
+    'NC': [36, 51, -109, -85],
+    'NE': [36, 48, -91, -62],
+    'NW': [35, 52, -126, -102],
+    'SC': [24, 41, -107, -86],
+    'SE': [22, 37, -93.5, -72],
+    'SW': [24.5, 45, -122, -103],
     'ATL': [31.2, 35.8, -87.4, -79.8],
     'CA-NV': [30, 45, -124, -114],
     'CentralCA': [34.5, 40.5, -124, -118],
     'CHI-DET': [39, 44, -92, -83],
     'DCArea': [36.7, 40, -81, -72],
     'EastCO': [36.5, 41.5, -108, -101.8],
-    'GreatLakes': [37, 50, -95, -70],
+    'GreatLakes': [37, 50, -96, -70],
     'HI': [16.6, 24.6, -157.6, -157.5],
     'NYC-BOS': [40, 43, -78.5, -68.5],
     'SEA-POR': [43, 50, -125, -119],
@@ -74,7 +74,7 @@ class Map():
         self.tile = kwargs.get('tile', 'full')
         self.airports = self.load_airports(airport_fn)
 
-        if self.tile == 'full':
+        if self.tile in ['full', 'conus']:
             self.corners = self.grid_info.pop('corners')
         else:
             self.corners = self.get_corners()
@@ -100,7 +100,7 @@ class Map():
                                 zorder=2,
                                 )
         else:
-            if self.tile != 'full':
+            if self.tile not in ['full', 'conus']:
                 self.m.drawcounties(antialiased=False,
                                     color='gray',
                                     linewidth=0.1,

--- a/adb_graphics/figures/maps.py
+++ b/adb_graphics/figures/maps.py
@@ -199,7 +199,10 @@ class DataMap():
         self.map = map_
 
 
-    def add_logo(self, ax):
+    @staticmethod
+    def add_logo(ax):
+
+        ''' Puts the NOAA logo at the bottom left of the matplotlib axes. '''
 
         logo = mpimg.imread('static/noaa-logo-100x100.png')
 

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -17,7 +17,6 @@ import time
 import zipfile
 
 import matplotlib.pyplot as plt
-from PIL import Image
 import yaml
 
 from adb_graphics.datahandler import grib
@@ -57,7 +56,7 @@ def create_maps(cla, fhr, grib_path, workdir):
                     msg = f'graphics: {variable} {level}'
                     raise errors.NoGraphicsDefinitionForVariable(msg)
 
-                args.append((cla, fhr, grib_path, level, spec,
+                args.append((fhr, grib_path, level, spec,
                              variable, workdir, tile))
 
     with Pool(processes=cla.nprocs) as pool:
@@ -240,7 +239,7 @@ def parse_args():
         )
     return parser.parse_args()
 
-def parallel_maps(cla, fhr, grib_path, level, spec, variable, workdir,
+def parallel_maps(fhr, grib_path, level, spec, variable, workdir,
                   tile='full'):
 
     # pylint: disable=too-many-arguments,too-many-locals
@@ -251,7 +250,6 @@ def parallel_maps(cla, fhr, grib_path, level, spec, variable, workdir,
 
     Input:
 
-      cla        command line arguments Namespace object
       fhr        forecast hour
       grib_path  the full path to the grib file
       level      the vertical level of the variable to be plotted

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -70,7 +70,7 @@ def create_maps(cla, fhr, grib_path, workdir):
                 msg = f'graphics: {variable} {level}'
                 raise errors.NoGraphicsDefinitionForVariable(msg)
 
-            args.append((fhr, grib_path, level, spec,
+            args.append((cla, fhr, grib_path, level, spec,
                          variable, workdir))
 
     with Pool(processes=cla.nprocs) as pool:
@@ -96,7 +96,7 @@ def load_images(arg):
     with open(image_file, 'r') as fn:
         images = yaml.load(fn, Loader=yaml.Loader)[image_set]
 
-    return [image_file, images.get('variables')]
+    return [images.get('grid_suffix'), images.get('variables')]
 
 def load_sites(arg):
 
@@ -230,7 +230,7 @@ def parse_args():
 
     return parser.parse_args()
 
-def parallel_maps(fhr, grib_path, level, spec, variable, workdir,
+def parallel_maps(cla, fhr, grib_path, level, spec, variable, workdir,
                   tile=''):
 
     # pylint: disable=too-many-arguments,too-many-locals
@@ -241,6 +241,7 @@ def parallel_maps(fhr, grib_path, level, spec, variable, workdir,
 
     Input:
 
+      cla        command line arguments Namespace object
       fhr        forecast hour
       grib_path  the full path to the grib file
       level      the vertical level of the variable to be plotted
@@ -255,6 +256,7 @@ def parallel_maps(fhr, grib_path, level, spec, variable, workdir,
     field = grib.fieldData(
         fhr=fhr,
         filename=grib_path,
+        grid_suffix=cla.images[0],
         level=level,
         short_name=variable,
         )
@@ -273,6 +275,7 @@ def parallel_maps(fhr, grib_path, level, spec, variable, workdir,
             contour_fields.append(grib.fieldData(
                 fhr=fhr,
                 filename=grib_path,
+                grid_suffix=cla.images[0],
                 level=lev,
                 contour_kwargs=contour_kwargs,
                 short_name=var,
@@ -287,6 +290,7 @@ def parallel_maps(fhr, grib_path, level, spec, variable, workdir,
             hatch_fields.append(grib.fieldData(
                 fhr=fhr,
                 filename=grib_path,
+                grid_suffix=cla.images[0],
                 level=lev,
                 contour_kwargs=hatch_kwargs,
                 short_name=var,
@@ -351,6 +355,7 @@ def parallel_skewt(cla, fhr, grib_path, site, workdir):
         fhr=fhr,
         filename=grib_path,
         filetype=cla.file_type,
+        grid_suffix=cla.images[0],
         loc=site,
         max_plev=cla.max_plev,
         )

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -97,7 +97,7 @@ def load_images(arg):
     with open(image_file, 'r') as fn:
         images = yaml.load(fn, Loader=yaml.Loader)[image_set]
 
-    return [images.get('grid_suffix'), images.get('variables')]
+    return [image_file, images.get('variables')]
 
 def load_sites(arg):
 
@@ -264,7 +264,6 @@ def parallel_maps(cla, fhr, grib_path, level, spec, variable, workdir,
     field = grib.fieldData(
         fhr=fhr,
         filename=grib_path,
-        grid_suffix=cla.images[0],
         level=level,
         short_name=variable,
         )
@@ -283,7 +282,6 @@ def parallel_maps(cla, fhr, grib_path, level, spec, variable, workdir,
             contour_fields.append(grib.fieldData(
                 fhr=fhr,
                 filename=grib_path,
-                grid_suffix=cla.images[0],
                 level=lev,
                 contour_kwargs=contour_kwargs,
                 short_name=var,
@@ -298,7 +296,6 @@ def parallel_maps(cla, fhr, grib_path, level, spec, variable, workdir,
             hatch_fields.append(grib.fieldData(
                 fhr=fhr,
                 filename=grib_path,
-                grid_suffix=cla.images[0],
                 level=lev,
                 contour_kwargs=hatch_kwargs,
                 short_name=var,
@@ -366,7 +363,6 @@ def parallel_skewt(cla, fhr, grib_path, site, workdir):
         fhr=fhr,
         filename=grib_path,
         filetype=cla.file_type,
-        grid_suffix=cla.images[0],
         loc=site,
         max_plev=cla.max_plev,
         )

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -72,7 +72,7 @@ def generate_tile_list(arg_list):
     if not arg_list:
         return ['full']
 
-    rap_only = ('AK', 'AKZoom', 'CONUS', 'HI')
+    rap_only = ('AK', 'AKZoom', 'conus', 'HI')
     if 'all' in arg_list:
         all_list = ['full'] + list(maps.TILE_DEFS.keys())
         return [tile for tile in all_list if tile not in rap_only]
@@ -231,7 +231,7 @@ def parse_args():
         )
     map_group.add_argument(
         '--tiles',
-        choices=['full', 'all'] + list(maps.TILE_DEFS.keys()),
+        choices=['full', 'all', 'conus'] + list(maps.TILE_DEFS.keys()),
         default=['full'],
         help='The domains to plot. Choose from any of those listed. Special \
         choices: full is full model output domain, and all is the full domain, \
@@ -305,14 +305,10 @@ def parallel_maps(cla, fhr, grib_path, level, spec, variable, workdir,
 
     _, ax = plt.subplots(1, 1, figsize=(12, 12))
 
-
-    corners = field.corners if tile == 'full' else None
-
     # Generate a map object
     m = maps.Map(
         airport_fn=AIRPORTS,
         ax=ax,
-        corners=corners,
         grid_info=field.grid_info,
         tile=tile,
         )
@@ -491,7 +487,8 @@ if __name__ == '__main__':
     print((('-' * 80)+'\n') * 2)
 
     for name, val in CLARGS.__dict__.items():
-        print(f"{name:>15s}: {val}")
+        if name != 'specs':
+            print(f"{name:>15s}: {val}")
 
 
     graphics_driver(CLARGS)

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -302,7 +302,7 @@ def parallel_maps(cla, fhr, grib_path, level, spec, variable, workdir,
     m = maps.Map(
         airport_fn=AIRPORTS,
         ax=ax,
-        corners=field.corners,
+        grid_info=field.grid_info,
         )
 
     # Send all objects (map, field, contours, hatches) to a DataMap object
@@ -336,7 +336,10 @@ def parallel_maps(cla, fhr, grib_path, level, spec, variable, workdir,
 
     plt.close()
 
-    add_logo(png_path, (20, 645))
+    if cla.images[0] == 'GRLL0':
+        add_logo(png_path, (80, 880))
+    else:
+        add_logo(png_path, (20, 645))
 
 
 def parallel_skewt(cla, fhr, grib_path, site, workdir):

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -231,7 +231,7 @@ def parse_args():
         )
     map_group.add_argument(
         '--tiles',
-        choices=['full', 'all', 'conus'] + list(maps.TILE_DEFS.keys()),
+        choices=['full', 'all', 'conus', 'AK'] + list(maps.TILE_DEFS.keys()),
         default=['full'],
         help='The domains to plot. Choose from any of those listed. Special \
         choices: full is full model output domain, and all is the full domain, \

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -72,8 +72,10 @@ def generate_tile_list(arg_list):
     if not arg_list:
         return ['full']
 
+    rap_only = ('AK', 'AKZoom', 'CONUS', 'HI')
     if 'all' in arg_list:
-        return ['full'] + list(maps.TILE_DEFS.keys())
+        all_list = ['full'] + list(maps.TILE_DEFS.keys())
+        return [tile for tile in all_list if tile not in rap_only]
 
     return arg_list
 

--- a/create_graphics.py
+++ b/create_graphics.py
@@ -29,20 +29,6 @@ import adb_graphics.utils as utils
 
 AIRPORTS = 'static/Airports_locs.txt'
 
-
-def add_logo(fpath, position):
-
-    ''' Add the NOAA logo to a PNG image file, fpath '''
-
-    logo_file = 'static/noaa-logo-100x100.png'
-    logo_image = Image.open(logo_file)
-
-    image = Image.open(fpath)
-    image.paste(logo_image,
-                position,
-                logo_image)
-    image.save(fpath)
-
 def create_skewt(cla, fhr, grib_path, workdir):
 
     ''' Generate arguments for parallel processing of Skew T graphics,
@@ -327,6 +313,7 @@ def parallel_maps(cla, fhr, grib_path, level, spec, variable, workdir,
     m = maps.Map(
         airport_fn=AIRPORTS,
         ax=ax,
+        corners=corners,
         grid_info=field.grid_info,
         tile=tile,
         )
@@ -362,12 +349,6 @@ def parallel_maps(cla, fhr, grib_path, level, spec, variable, workdir,
         )
 
     plt.close()
-
-    if cla.images[0] == 'GRLL0':
-        add_logo(png_path, (80, 880))
-    else:
-        add_logo(png_path, (20, 645))
-
 
 def parallel_skewt(cla, fhr, grib_path, site, workdir):
 
@@ -407,7 +388,6 @@ def parallel_skewt(cla, fhr, grib_path, site, workdir):
         )
     plt.close()
 
-    add_logo(png_path, (125, 875))
 
 @utils.timer
 def graphics_driver(cla):

--- a/image_lists/hrrr.yml
+++ b/image_lists/hrrr.yml
@@ -1,5 +1,4 @@
 hourly:
-  grid_suffix: GLC0
   variables:
     1hsm:
       - sfc

--- a/image_lists/hrrr.yml
+++ b/image_lists/hrrr.yml
@@ -55,17 +55,10 @@ hourly:
       - ua
     dewp:
       - 2m
-    ectp:
+    echotop:
       - sfc
     flru:
       - sfc
-    hail:
-      - maxsfc
-      - max
-    hailcast:
-      - maxsfc
-    gust:
-      - 10m
     G113bt:
       - sat
     G114bt:
@@ -74,6 +67,13 @@ hourly:
       - sat
     G124bt:
       - sat
+    gust:
+      - 10m
+    hail:
+      - maxsfc
+      - max
+    hailcast:
+      - maxsfc
     hlcy:
       - esbl
       - in16
@@ -86,6 +86,8 @@ hourly:
       - mx03
       - mx16
       - sfc
+      - sr01
+      - sr03
     hlcytot:
       - mn02
       - mn03
@@ -101,11 +103,12 @@ hourly:
       - esbl
     hvyacp:
       - esbl
-    li:
-      - best
     lcl:
       - sfc
     lhtfl:
+      - sfc
+    li:
+      - best
       - sfc
     ltg1:
       - sfc
@@ -119,7 +122,7 @@ hourly:
       - sfc
     pchg:
       - sfc
-    ptemp:
+    ptmp:
       - 2m
     ptyp:
       - sfc
@@ -136,10 +139,11 @@ hourly:
       - sfc
     rvil:
       - sfc
-    s1shr:
-      - sfc
     sfcp:
       - sfc
+    shear:
+      - 01km
+      - 06km
     shtfl:
       - sfc
     slw:
@@ -177,10 +181,10 @@ hourly:
       - sfc
     ulwrf:
       - sfc
-      - nta
+      - top
     uswrf:
       - sfc
-      - nta
+      - top
     vbdsf:
       - sfc
     vddsf:
@@ -195,6 +199,7 @@ hourly:
       - 500mb
     vvel:
       - 700mb
+      - mean
     vvort:
       - mx01
       - mx02

--- a/image_lists/hrrr.yml
+++ b/image_lists/hrrr.yml
@@ -1,29 +1,80 @@
 hourly:
+  grid_suffix: GLC0
   variables:
-    rh:
-      - 2m
-      - 850mb
-      - ua
-    temp:
-      - 2ds
-      - 2m
-      - 500mb
-      - 700mb
-      - 850mb
-      - 925mb
+    1hsm:
       - sfc
-    wind:
-      - 10m
-      - 80m
-      - 850mb
-      - 250mb
+    1hsnw:
+      - sfc
+    1ref:
+      - sfc
+    3hsm:
+      - sfc
+    6kshr:
+      - sfc
+    acfrzr:
+      - sfc
+    acfrozr:
+      - sfc
+    acpcp:
+      - sfc
+    acsnod:
+      - sfc
+    acp:
+      - esbl
+      - esblmn
+      - sfc
+    acsnw:
+      - esbl
+      - esblmn
+      - sfc
+    blcc:
+      - sfc
+    cape:
+      - sfc
+      - mu
+      - mul
+      - mx90mb
+    ceil:
+      - ua
+    ceilexp:
+      - ua
+    ceilexp2:
+      - ua
+    cin:
+      - sfc
+    cloudcover:
+      - high
+      - low
+      - mid
+      - total
+    cpofp:
+      - sfc
+    cref:
+      - esbl
+      - sfc
+    ctop:
+      - ua
+    dewp:
+      - 2m
+    ectp:
+      - sfc
+    flru:
+      - sfc
+    hail:
+      - maxsfc
       - max
-      - mdn
-      - mup
-    vort:
-      - 500mb
-    vvel:
-      - 700mb
+    hailcast:
+      - maxsfc
+    gust:
+      - 10m
+    G113bt:
+      - sat
+    G114bt:
+      - sat
+    G123bt:
+      - sat
+    G124bt:
+      - sat
     hlcy:
       - esbl
       - in16
@@ -45,89 +96,14 @@ hourly:
       - mx03
       - mx16
       - mx25
-    dewp:
-      - 2m
-    gust:
-      - 10m
-    ptemp:
-      - 2m
-    wchg:
-      - 80m
-      - esbl
-    wpwr:
-      - 80m
-    pwtr:
-      - sfc
-    acp:
-      - esbl
-      - esblmn
-      - sfc
-    acsnw:
-      - esbl
-      - esblmn
-      - sfc
-    hvyacp:
-      - esbl
-    hvy1snw:
-      - esbl
-    cref:
-      - esbl
-      - sfc
-    totp:
-      - esbl
-      - esblmn
-      - sfc
-    vvort:
-      - mx01
-      - mx02
-    1hsm:
-      - sfc
-    1hsnw:
-      - sfc
-    1ref:
-      - sfc
-    3hsm:
-      - sfc
-    6kshr:
-      - sfc
-    acsnod:
-      - sfc
-    acpcp:
-      - sfc
-    acfrzr:
-      - sfc
-    acfrozr:
-      - sfc
-    blcc:
-      - sfc
-    li:
-      - best
-    cape:
-      - sfc
-      - mu
-      - mul
-      - mx90mb
-    cin:
-      - sfc
-    cloudcover:
-      - high
-      - low
-      - mid
-      - total
-    cpofp:
-      - sfc
-    ectp:
-      - sfc
-    flru:
-      - sfc
-    hail:
-      - maxsfc
-    hailcast:
-      - maxsfc
-    hail:
-      - max
     hpbl:
       - sfc
+    hvy1snw:
+      - esbl
+    hvyacp:
+      - esbl
+    li:
+      - best
     lcl:
       - sfc
     lhtfl:
@@ -144,8 +120,19 @@ hourly:
       - sfc
     pchg:
       - sfc
+    ptemp:
+      - 2m
     ptyp:
       - sfc
+    pwtr:
+      - sfc
+    ref:
+      - m10
+      - maxm10
+    rh:
+      - 2m
+      - 850mb
+      - ua
     rhpw:
       - sfc
     rvil:
@@ -162,9 +149,32 @@ hourly:
       - sfc
     soilm:
       - sfc
+    soilt: &soilt_levs
+      - 0cm
+      - 1cm
+      - 4cm
+      - 10cm
+      - 30cm
+      - 60cm
+      - 1m
+      - 1.6m
+      - 3m
+    soilw: *soilt_levs
     solar:
       - sfc
     ssrun:
+      - sfc
+    temp:
+      - 2ds
+      - 2m
+      - 500mb
+      - 700mb
+      - 850mb
+      - 925mb
+      - sfc
+    totp:
+      - esbl
+      - esblmn
       - sfc
     ulwrf:
       - sfc
@@ -178,39 +188,29 @@ hourly:
       - sfc
     vig:
       - sfc
-    vis:
-      - sfc
     vil:
       - sfc
+    vis:
+      - sfc
+    vort:
+      - 500mb
+    vvel:
+      - 700mb
+    vvort:
+      - mx01
+      - mx02
+    wchg:
+      - 80m
+      - esbl
     weasd:
       - sfc
-    soilt: &soilt_levs
-      - 0cm
-      - 1cm
-      - 4cm
-      - 10cm
-      - 30cm
-      - 60cm
-      - 1m
-      - 1.6m
-      - 3m
-    soilw: *soilt_levs
-    ref:
-      - m10
-      - maxm10
-    G113bt:
-      - sat
-    G114bt:
-      - sat
-    G123bt:
-      - sat
-    G124bt:
-      - sat
-    ceil:
-      - ua
-    ceilexp:
-      - ua
-    ceilexp2:
-      - ua
-    ctop:
-      - ua
+    wind:
+      - 10m
+      - 80m
+      - 850mb
+      - 250mb
+      - max
+      - mdn
+      - mup
+    wpwr:
+      - 80m

--- a/image_lists/hrrr_subset.yml
+++ b/image_lists/hrrr_subset.yml
@@ -1,7 +1,5 @@
 hourly:
   variables:
-    1ref:
-      - sfc
     acfrzr:
       - sfc
     acfrozr:
@@ -29,7 +27,6 @@ hourly:
     cpofp:
       - sfc
     cref:
-      - esbl
       - sfc
     ctop:
       - ua
@@ -86,7 +83,6 @@ hourly:
     rh:
       - 2m
       - 850mb
-      - ua
     rvil:
       - sfc
     shear:

--- a/image_lists/hrrr_subset.yml
+++ b/image_lists/hrrr_subset.yml
@@ -1,5 +1,4 @@
 hourly:
-  grid_suffix: GLC0
   variables:
 #    rh:
 #      - 2m

--- a/image_lists/hrrr_subset.yml
+++ b/image_lists/hrrr_subset.yml
@@ -1,72 +1,72 @@
 hourly:
   variables:
-    rh:
-      - 2m
-      - 850mb
-    temp:
-      - 2ds
-      - 2m
-      - 500mb
-      - 700mb
-      - 850mb
-      - 925mb
-      - sfc
-    vort:
-      - 500mb
-    vvel:
-      - 700mb
-    hlcy:
-      - in16
-      - in25
-      - mx02
-      - mx03
-      - mx16
-    dewp:
-      - 2m
-    gust:
-      - 10m
-    vvort:
-      - mx01
-      - mx02
-    cape:
-      - sfc
-      - mu
-      - mul
-      - mx90mb
-    cin:
-      - sfc
-    cloudcover:
-      - high
-      - low
-      - mid
-      - total
-    lcl:
-      - sfc
-    vil:
-      - sfc
-    soilt: &soilt_levs
-      - 0cm
-      - 1cm
-      - 4cm
-      - 10cm
-      - 30cm
-      - 60cm
-      - 1m
-      - 1.6m
-      - 3m
-    G113bt:
-      - sat
-    G114bt:
-      - sat
-    G123bt:
-      - sat
-    G124bt:
-      - sat
+#    rh:
+#      - 2m
+#      - 850mb
+#    temp:
+#      - 2ds
+#      - 2m
+#      - 500mb
+#      - 700mb
+#      - 850mb
+#      - 925mb
+#      - sfc
+#    vort:
+#      - 500mb
+#    vvel:
+#      - 700mb
+#    hlcy:
+#      - in16
+#      - in25
+#      - mx02
+#      - mx03
+#      - mx16
+#    dewp:
+#      - 2m
+#    gust:
+#      - 10m
+#    vvort:
+#      - mx01
+#      - mx02
+#    cape:
+#      - sfc
+#      - mu
+#      - mul
+#      - mx90mb
+#    cin:
+#      - sfc
+#    cloudcover:
+#      - high
+#      - low
+#      - mid
+#      - total
+#    lcl:
+#      - sfc
+#    vil:
+#      - sfc
+#    soilt: &soilt_levs
+#      - 0cm
+#      - 1cm
+#      - 4cm
+#      - 10cm
+#      - 30cm
+#      - 60cm
+#      - 1m
+#      - 1.6m
+#      - 3m
+#    G113bt:
+#      - sat
+#    G114bt:
+#      - sat
+#    G123bt:
+#      - sat
+#    G124bt:
+#      - sat
     ceil:
       - ua
-    ceilexp:
-      - ua
-    ceilexp2:
-      - ua
-    ctop:
-      - ua
+#    ceilexp:
+#      - ua
+#    ceilexp2:
+#      - ua
+#    ctop:
+#      - ua

--- a/image_lists/hrrr_subset.yml
+++ b/image_lists/hrrr_subset.yml
@@ -1,4 +1,5 @@
 hourly:
+  grid_suffix: GLC0
   variables:
 #    rh:
 #      - 2m

--- a/image_lists/hrrr_subset.yml
+++ b/image_lists/hrrr_subset.yml
@@ -1,72 +1,149 @@
 hourly:
   variables:
-#    rh:
-#      - 2m
-#      - 850mb
-#    temp:
-#      - 2ds
-#      - 2m
-#      - 500mb
-#      - 700mb
-#      - 850mb
-#      - 925mb
-#      - sfc
-#    vort:
-#      - 500mb
-#    vvel:
-#      - 700mb
-#    hlcy:
-#      - in16
-#      - in25
-#      - mx02
-#      - mx03
-#      - mx16
-#    dewp:
-#      - 2m
-#    gust:
-#      - 10m
-#    vvort:
-#      - mx01
-#      - mx02
-#    cape:
-#      - sfc
-#      - mu
-#      - mul
-#      - mx90mb
-#    cin:
-#      - sfc
-#    cloudcover:
-#      - high
-#      - low
-#      - mid
-#      - total
-#    lcl:
-#      - sfc
-#    vil:
-#      - sfc
-#    soilt: &soilt_levs
-#      - 0cm
-#      - 1cm
-#      - 4cm
-#      - 10cm
-#      - 30cm
-#      - 60cm
-#      - 1m
-#      - 1.6m
-#      - 3m
-#    G113bt:
-#      - sat
-#    G114bt:
-#      - sat
-#    G123bt:
-#      - sat
-#    G124bt:
-#      - sat
+    1ref:
+      - sfc
+    acfrzr:
+      - sfc
+    acfrozr:
+      - sfc
+    acpcp:
+      - sfc
+    cape:
+      - sfc
+      - mu
+      - mul
+      - mx90mb
     ceil:
       - ua
-#    ceilexp:
-#      - ua
-#    ceilexp2:
-#      - ua
-#    ctop:
-#      - ua
+    ceilexp:
+      - ua
+    ceilexp2:
+      - ua
+    cin:
+      - sfc
+    cloudcover:
+      - high
+      - low
+      - mid
+      - total
+    cpofp:
+      - sfc
+    cref:
+      - esbl
+      - sfc
+    ctop:
+      - ua
+    dewp:
+      - 2m
+    echotop:
+      - sfc
+    G113bt:
+      - sat
+    G114bt:
+      - sat
+    G123bt:
+      - sat
+    G124bt:
+      - sat
+    gust:
+      - 10m
+    hail:
+      - maxsfc
+      - max
+    hailcast:
+      - maxsfc
+    hlcy:
+      - in16
+      - in25
+      - mn02
+      - mn03
+      - mn16
+      - mn25
+      - mx02
+      - mx03
+      - mx16
+      - mx25
+      - sr01
+      - sr03
+    lcl:
+      - sfc
+    lhtfl:
+      - sfc
+    li:
+      - best
+      - sfc
+    ltg3:
+      - sfc
+    mref:
+      - sfc
+    ptmp:
+      - 2m
+    pwtr:
+      - sfc
+    ref:
+      - m10
+      - maxm10
+    rh:
+      - 2m
+      - 850mb
+      - ua
+    rvil:
+      - sfc
+    shear:
+      - 01km
+      - 06km
+    shtfl:
+      - sfc
+    soilm:
+      - sfc
+    soilt: &soilt_levs
+      - 0cm
+      - 1cm
+      - 4cm
+      - 10cm
+      - 30cm
+      - 60cm
+      - 1m
+      - 1.6m
+      - 3m
+    soilw: *soilt_levs
+    solar:
+      - sfc
+    ssrun:
+      - sfc
+    temp:
+      - 2ds
+      - 2m
+      - 500mb
+      - 700mb
+      - 850mb
+      - 925mb
+      - sfc
+    totp:
+      - sfc
+    ulwrf:
+      - sfc
+      - top
+    uswrf:
+      - sfc
+      - top
+    vbdsf:
+      - sfc
+    vddsf:
+      - sfc
+    vig:
+      - sfc
+    vil:
+      - sfc
+    vis:
+      - sfc
+    vort:
+      - 500mb
+    vvel:
+      - 700mb
+      - mean
+    vvort:
+      - mx01
+      - mx02
+    weasd:
+      - sfc

--- a/image_lists/rap.yml
+++ b/image_lists/rap.yml
@@ -1,0 +1,114 @@
+hourly:
+  grid_suffix: GRLL0
+  variables:
+#    1hsnw:
+#      - sfc
+#    acp:
+#      - sfc
+#    acsnw:
+#      - sfc
+#    acfrozr:
+#      - sfc
+#    acfrzr:
+#      - sfc
+#    acpcp:
+#      - sfc
+    cape:
+      - mu
+#      - mul
+#      - mx90mb
+#      - sfc
+#    cctop:
+#      - ua
+#    ceil:
+#      - ua
+#    ctop:
+#      - ua
+#    cin:
+#      - sfc
+#    cloudcover:
+#      - high
+#      - low
+#      - mid
+#      - total
+#    cref:
+#      - sfc
+#    dewp:
+#      - 2m
+#    ectp:
+#      - sfc
+#    flru:
+#      - sfc
+#    gust:
+#      - 10m
+#    hpbl:
+#      - sfc
+#    lhtfl:
+#      - sfc
+#    ltng:
+#      - sfc
+#    pchg:
+#      - sfc
+#    ptemp:
+#      - 2m
+#    ptyp:
+#      - sfc
+#    pwtr:
+#      - sfc
+#    rh:
+#      - 2m
+#      - 850mb
+#      - ua
+#    rhpw:
+#      - sfc
+#    rvil:
+#      - sfc
+#    shtfl:
+#      - sfc
+#    snod:
+#      - sfc
+#    soilt: &soilt_levs
+#      - 1cm
+#      - 4cm
+#      - 10cm
+#    soilw:
+#      <<: *soilt_levs
+#      - 0cm
+#    solar:
+#      - sfc
+#    temp:
+#      - 2ds
+#      - 2m
+#      - 500mb
+#      - 700mb
+#      - 850mb
+#      - 925mb
+#      - sfc
+#    totp:
+#      - sfc
+#    ulwrf:
+#      - sfc
+#      - nta
+#    uswrf:
+#      - sfc
+#      - nta
+#    vil:
+#      - sfc
+#    vis:
+#      - sfc
+#    vort:
+#      - 500mb
+#    vvel:
+#      - 700mb
+#    wchg:
+#      - 80m
+#    wind:
+#      - 10m
+#      - 80m
+#      - 850mb
+#      - 250mb
+#    wmag:
+#      - 250mb
+#      - 850mb
+#    weasd:
+#      - sfc

--- a/image_lists/rap.yml
+++ b/image_lists/rap.yml
@@ -1,5 +1,4 @@
 hourly:
-  grid_suffix: GRLL0
   variables:
 #    1hsnw:
 #      - sfc

--- a/image_lists/rap.yml
+++ b/image_lists/rap.yml
@@ -1,113 +1,113 @@
 hourly:
   variables:
-#    1hsnw:
-#      - sfc
-#    acp:
-#      - sfc
-#    acsnw:
-#      - sfc
-#    acfrozr:
-#      - sfc
-#    acfrzr:
-#      - sfc
-#    acpcp:
-#      - sfc
+    1hsnw:
+      - sfc
+    acp:
+      - sfc
+    acsnw:
+      - sfc
+    acfrozr:
+      - sfc
+    acfrzr:
+      - sfc
+    acpcp:
+      - sfc
     cape:
       - mu
-#      - mul
-#      - mx90mb
-#      - sfc
-#    cctop:
-#      - ua
-#    ceil:
-#      - ua
-#    ctop:
-#      - ua
-#    cin:
-#      - sfc
-#    cloudcover:
-#      - high
-#      - low
-#      - mid
-#      - total
-#    cref:
-#      - sfc
-#    dewp:
-#      - 2m
-#    ectp:
-#      - sfc
-#    flru:
-#      - sfc
-#    gust:
-#      - 10m
-#    hpbl:
-#      - sfc
-#    lhtfl:
-#      - sfc
-#    ltng:
-#      - sfc
-#    pchg:
-#      - sfc
-#    ptemp:
-#      - 2m
-#    ptyp:
-#      - sfc
-#    pwtr:
-#      - sfc
-#    rh:
-#      - 2m
-#      - 850mb
-#      - ua
-#    rhpw:
-#      - sfc
-#    rvil:
-#      - sfc
-#    shtfl:
-#      - sfc
-#    snod:
-#      - sfc
-#    soilt: &soilt_levs
-#      - 1cm
-#      - 4cm
-#      - 10cm
-#    soilw:
-#      <<: *soilt_levs
-#      - 0cm
-#    solar:
-#      - sfc
-#    temp:
-#      - 2ds
-#      - 2m
-#      - 500mb
-#      - 700mb
-#      - 850mb
-#      - 925mb
-#      - sfc
-#    totp:
-#      - sfc
-#    ulwrf:
-#      - sfc
-#      - nta
-#    uswrf:
-#      - sfc
-#      - nta
-#    vil:
-#      - sfc
-#    vis:
-#      - sfc
-#    vort:
-#      - 500mb
-#    vvel:
-#      - 700mb
-#    wchg:
-#      - 80m
-#    wind:
-#      - 10m
-#      - 80m
-#      - 850mb
-#      - 250mb
-#    wmag:
-#      - 250mb
-#      - 850mb
-#    weasd:
-#      - sfc
+      - mul
+      - mx90mb
+      - sfc
+    cctop:
+      - ua
+    ceil:
+      - ua
+    ctop:
+      - ua
+    cin:
+      - sfc
+    cloudcover:
+      - high
+      - low
+      - mid
+      - total
+    cref:
+      - sfc
+    dewp:
+      - 2m
+    ectp:
+      - sfc
+    flru:
+      - sfc
+    gust:
+      - 10m
+    hpbl:
+      - sfc
+    lhtfl:
+      - sfc
+    ltng:
+      - sfc
+    pchg:
+      - sfc
+    ptemp:
+      - 2m
+    ptyp:
+      - sfc
+    pwtr:
+      - sfc
+    rh:
+      - 2m
+      - 850mb
+      - ua
+    rhpw:
+      - sfc
+    rvil:
+      - sfc
+    shtfl:
+      - sfc
+    snod:
+      - sfc
+    soilt: &soilt_levs
+      - 1cm
+      - 4cm
+      - 10cm
+    soilw:
+      <<: *soilt_levs
+      - 0cm
+    solar:
+      - sfc
+    temp:
+      - 2ds
+      - 2m
+      - 500mb
+      - 700mb
+      - 850mb
+      - 925mb
+      - sfc
+    totp:
+      - sfc
+    ulwrf:
+      - sfc
+      - nta
+    uswrf:
+      - sfc
+      - nta
+    vil:
+      - sfc
+    vis:
+      - sfc
+    vort:
+      - 500mb
+    vvel:
+      - 700mb
+    wchg:
+      - 80m
+    wind:
+      - 10m
+      - 80m
+      - 850mb
+      - 250mb
+    wmag:
+      - 250mb
+      - 850mb
+    weasd:
+      - sfc


### PR DESCRIPTION
This adds the necessary changes for creating RAP maps.

- Template the NCL variable names to include grid definition (retrieved from first variable entry of file).
- Support Lambert conformal, stereographic, and rotated lat/lon.
- Define single set of sub domains used by both RAP and HRRR.
- Move add_logo from create_graphics.py to figures maps.py to put it consistently in same place for all domains.
- Define wind stride based on domain.
- Update image_lists/hrrr_subset.yml, and alphabetize image lists.

This parallel version will not support timely generation of all graphics in a single job. More work is needed to support that effort.

Passes tests/linter.
